### PR TITLE
feat: add ZSH core config with Oh My Zsh + Oh My Posh

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,0 +1,31 @@
+ZDOTDIR="${ZDOTDIR:-$HOME}"
+
+export HISTFILE="${ZDOTDIR}/.zsh_history"
+export HISTSIZE=10000
+export SAVEHIST=10000
+setopt HIST_IGNORE_DUPS
+setopt SHARE_HISTORY
+
+export ZSH="${HOME}/.oh-my-zsh"
+export EDITOR="nvim"
+
+ZSH_THEME=""
+
+HYPHEN_INSENSITIVE="true"
+COMPLETION_WAITING_DOTS="true"
+
+plugins=(git zsh-syntax-highlighting zsh-autosuggestions)
+
+source "${ZSH}/oh-my-zsh.sh"
+
+eval "$(oh-my-posh init zsh --config "${HOME}/.cache/oh-my-posh/themes/material.omp.json")"
+
+# source modular config files
+for config_file in aliases functions keybindings completions; do
+  [[ -f "${ZDOTDIR}/${config_file}.zsh" ]] && source "${ZDOTDIR}/${config_file}.zsh"
+done
+
+# blank line between prompts
+_print_blank_line() { print "" }
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _print_blank_line

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -1,0 +1,10 @@
+alias g="git"
+alias vim="nvim"
+alias vi="nvim"
+
+alias cl="clear && ls"
+alias cs="clear && git status"
+alias sz='source "${ZDOTDIR}/.zshrc"'
+
+alias pth='echo $PATH | tr : "\n" | less'
+alias sau="sudo apt update && sudo apt upgrade"

--- a/zsh/completions.zsh
+++ b/zsh/completions.zsh
@@ -1,0 +1,13 @@
+# dotnet CLI completion
+_dotnet_zsh_complete() {
+  local completions=("$(dotnet complete --position $CURSOR "$BUFFER" 2>/dev/null)")
+  reply=(${(ps:\n:)completions})
+}
+if command -v dotnet &>/dev/null; then
+  compctl -K _dotnet_zsh_complete dotnet
+fi
+
+# GitHub Copilot CLI
+if command -v gh &>/dev/null; then
+  eval "$(gh copilot alias -- zsh)"
+fi

--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -1,0 +1,52 @@
+find_dir() {
+  local search_path="${1:-.}"
+  local depth="${2:-0}"
+  find "${search_path}" -maxdepth $((depth + 1)) -type d \
+    -not -path '*/node_modules/*' \
+    -not -path '*/.*' \
+    -not -path '*/bin/*' \
+    -not -path '*/obj/*' 2>/dev/null | fzf
+}
+
+find_dir_and_go() {
+  local search_path="${1:-.}"
+  local depth="${2:-0}"
+  local choice
+  choice=$(find_dir "${search_path}" "${depth}")
+  [[ -n "${choice}" ]] && cd "${choice}"
+}
+
+alias fd="find_dir_and_go"
+
+fp() {
+  find_dir_and_go "${HOME}/projects" 0
+}
+
+fdx() {
+  find_dir_and_go "${HOME}/Exercism" 1
+}
+
+fdev() {
+  local search_path="${1:-${HOME}/projects}"
+  local depth="${2:-0}"
+  local session_name="${3:-}"
+
+  local choice
+  choice=$(find_dir "${search_path}" "${depth}")
+  [[ -z "${choice}" ]] && return
+
+  if [[ -z "${session_name}" ]]; then
+    session_name=$(basename "${choice}")
+  fi
+
+  local win_path
+  win_path=$(wslpath -w "${choice}")
+
+  wt.exe new-tab -d "${win_path}" --title "${session_name}" --suppressApplicationTitle \; \
+    split-pane -d "${win_path}" --vertical --size .7 --title "${session_name}" --suppressApplicationTitle wsl.exe -e nvim \; \
+    move-focus left
+}
+
+owd() {
+  explorer.exe "$(wslpath -w "$(pwd)")"
+}

--- a/zsh/keybindings.zsh
+++ b/zsh/keybindings.zsh
@@ -1,0 +1,15 @@
+bindkey -v
+
+# reduce mode switch delay
+export KEYTIMEOUT=1
+
+# history search with up/down in vi mode
+bindkey '^[[A' history-beginning-search-backward
+bindkey '^[[B' history-beginning-search-forward
+bindkey -a 'k' history-beginning-search-backward
+bindkey -a 'j' history-beginning-search-forward
+
+# autosuggestion navigation (mirrors PSReadLine Ctrl+n/p/y)
+bindkey '^n' autosuggest-fetch
+bindkey '^p' up-line-or-history
+bindkey '^y' autosuggest-accept


### PR DESCRIPTION
## Summary

Adds a modular ZSH configuration for Ubuntu/WSL that mirrors the existing PowerShell profile.

### New files in \zsh/\

| File | Purpose |
|------|---------|
| \.zshrc\ | Main config — Oh My Zsh framework + Oh My Posh (material theme) prompt |
| \liases.zsh\ | \g\→git, \im\/\i\→nvim, common shell aliases |
| \unctions.zsh\ | fzf directory navigation: \d\, \p\, \dx\, \dev\ (WT tabs+splits via \wt.exe\) |
| \keybindings.zsh\ | Vi mode + Ctrl+n/p/y for autosuggestion navigation |
| \completions.zsh\ | dotnet CLI + GitHub Copilot CLI completions |

### Approach

- Uses **ZDOTDIR** so ZSH loads config directly from the repo (only \~/.zshenv\ needed in home dir)
- **Oh My Posh** with the same \material\ theme as PowerShell for visual consistency
- **fdev** function ported to ZSH using \wt.exe\ from WSL for Windows Terminal tabs+splits
- Vi mode + autosuggestion keybindings mirror PSReadLine behavior

### Follow-up PRs
- \eat/zsh-init\ — Bootstrap script (install oh-my-zsh, oh-my-posh, plugins, create \~/.zshenv\, symlink nvim)
- \eat/zsh-readme\ — README documentation update