### PR TITLE
fix: add ~/bin to PATH in init.sh before oh-my-posh check

### DIFF
--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -108,6 +108,9 @@ else
 fi
 
 # ── Oh My Posh ─────────────────────────────────────────────────────
+# oh-my-posh installs to ~/bin by default
+export PATH="${HOME}/bin:${PATH}"
+
 if ! command -v oh-my-posh &>/dev/null; then
   echo "Installing Oh My Posh..."
   curl -s https://ohmyposh.dev/install.sh | bash -s

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -109,7 +109,10 @@ fi
 
 # ── Oh My Posh ─────────────────────────────────────────────────────
 # oh-my-posh installs to ~/bin by default
-export PATH="${HOME}/bin:${PATH}"
+case ":${PATH:-}:" in
+  *:"${HOME}/bin":*) ;;
+  *) export PATH="${HOME}/bin${PATH:+:${PATH}}" ;;
+esac
 
 if ! command -v oh-my-posh &>/dev/null; then
   echo "Installing Oh My Posh..."


### PR DESCRIPTION
## Problem

`oh-my-posh` installer places the binary in `~/bin`, but `init.sh` doesn't have `~/bin` on PATH. This causes `command -v oh-my-posh` to fail immediately after install, and the theme download + summary lines also can't find it.

## Fix

Add `export PATH="${HOME}/bin:${PATH}"` before the oh-my-posh section in `init.sh`.