### PR TITLE
fix: guard external tools and fix PATH for fresh installs

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -25,7 +25,9 @@ plugins=(git zsh-syntax-highlighting zsh-autosuggestions)
 
 source "${ZSH}/oh-my-zsh.sh"
 
-eval "$(oh-my-posh init zsh --config "${HOME}/.cache/oh-my-posh/themes/material.omp.json")"
+if (( $+commands[oh-my-posh] )); then
+  eval "$(oh-my-posh init zsh --config "${HOME}/.cache/oh-my-posh/themes/material.omp.json")"
+fi
 
 # source modular config files
 for config_file in aliases functions keybindings completions; do


### PR DESCRIPTION
## Problem

On a fresh Ubuntu/WSL install before `init.sh` has run, zsh startup fails with:

```
.zshrc:28: command not found: oh-my-posh
error: Invalid command format. Did you mean: copilot -i "zsh"?
```

Additionally, `oh-my-posh` installs to `~/.local/bin` (not `~/bin` as previously assumed), so even after running `init.sh` it wasn't found.

## Fixes

| File | Change |
|------|--------|
| `.zshrc` | Add `~/.local/bin` to `path` array (oh-my-posh install location) |
| `.zshrc` | Guard `oh-my-posh init` with `$+commands` check |
| `completions.zsh` | Guard `gh copilot alias` — only eval on success, suppress stderr |
| `init.sh` | Add `~/.local/bin` to PATH before oh-my-posh check |

Supersedes #8.