### PR TITLE
fix: add ~/.local/bin to PATH and guard copilot alias for fresh installs

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,7 +1,7 @@
 ZDOTDIR="${ZDOTDIR:-$HOME}"
 
 typeset -U path
-path=("${HOME}/bin" $path)
+path=("${HOME}/.local/bin" "${HOME}/bin" $path)
 
 # nvm
 export NVM_DIR="${HOME}/.nvm"

--- a/zsh/completions.zsh
+++ b/zsh/completions.zsh
@@ -9,7 +9,6 @@ fi
 
 # GitHub Copilot CLI aliases
 if command -v gh &>/dev/null; then
-  local _copilot_aliases
   _copilot_aliases="$(gh copilot alias -- zsh 2>/dev/null)" && eval "${_copilot_aliases}"
   unset _copilot_aliases
 fi

--- a/zsh/completions.zsh
+++ b/zsh/completions.zsh
@@ -7,7 +7,9 @@ if command -v dotnet &>/dev/null; then
   compctl -K _dotnet_zsh_complete dotnet
 fi
 
-# GitHub Copilot CLI
+# GitHub Copilot CLI aliases
 if command -v gh &>/dev/null; then
-  eval "$(gh copilot alias -- zsh)"
+  local _copilot_aliases
+  _copilot_aliases="$(gh copilot alias -- zsh 2>/dev/null)" && eval "${_copilot_aliases}"
+  unset _copilot_aliases
 fi

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -108,6 +108,12 @@ else
 fi
 
 # ── Oh My Posh ─────────────────────────────────────────────────────
+# oh-my-posh installs to ~/.local/bin by default
+case ":${PATH:-}:" in
+  *:"${HOME}/.local/bin":*) ;;
+  *) export PATH="${HOME}/.local/bin${PATH:+:${PATH}}" ;;
+esac
+
 if ! command -v oh-my-posh &>/dev/null; then
   echo "Installing Oh My Posh..."
   curl -s https://ohmyposh.dev/install.sh | bash -s


### PR DESCRIPTION
## Problem

Fixes that were pushed to PR #9 after it was already merged. On a fresh install:

1. `oh-my-posh` installs to `~/.local/bin`, not `~/bin` — wasn't on PATH
2. `gh copilot alias -- zsh` fails when the copilot extension isn't set up, producing:
   ```
   error: Invalid command format. Did you mean: copilot -i "zsh"?
   ```

## Changes

| File | Fix |
|------|-----|
| `.zshrc` | Add `~/.local/bin` to `path` array |
| `completions.zsh` | Guard `gh copilot alias` — only eval on success, suppress stderr |
| `init.sh` | Add `~/.local/bin` to PATH before oh-my-posh check |