### PR TITLE
feat: add .NET SDK to zsh init and document bootstrap scripts

### DIFF
--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -15,3 +15,28 @@ Use **trunk-based development** against `master`. Never commit directly to `mast
 - Before pushing, merge `master` into the feature branch to keep it up to date
 - After addressing review feedback, commit and push the fixes, then reply to each comment thread
 - When creating PRs, include a summary table of changes and note any dependencies on other PRs
+
+## Bootstrap Scripts
+
+### `zsh/init.sh` — Linux/WSL bootstrap
+
+Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
+
+| Category | Tools |
+|----------|-------|
+| apt packages | zsh, fzf, ripgrep, curl, wget, git, build-essential, unzip |
+| Neovim | Latest stable from GitHub releases (supports `--force` for upgrades) |
+| .NET SDK | Latest LTS via `dotnet-install.sh` to `~/.dotnet` (needed for csharp_ls, fsautocomplete) |
+| nvm + Node | nvm + Node LTS (needed for Copilot CLI, Mason LSP servers) |
+| Oh My Zsh | Framework + zsh-syntax-highlighting, zsh-autosuggestions plugins |
+| GitHub CLI | `gh` from official apt repo |
+| Copilot CLI | `@github/copilot` via npm |
+| Oh My Posh | Prompt theme engine to `~/.local/bin` |
+
+Also configures: `ZDOTDIR` via `~/.zshenv`, nvim config symlink, default shell to zsh.
+
+When adding a new tool dependency (e.g., a new Mason LSP server that needs a runtime), add the install step to this script and ensure the runtime's bin directory is on PATH in both `init.sh` and `.zshrc`.
+
+### `win/init.ps1` — Windows bootstrap
+
+Installs dev tools via **winget** (primary) and **Chocolatey** (fallback). Includes Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, and other dev tools. Does not currently install .NET SDK — add via winget if needed.

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,7 +1,11 @@
 ZDOTDIR="${ZDOTDIR:-$HOME}"
 
 typeset -U path
-path=("${HOME}/.local/bin" "${HOME}/bin" $path)
+path=("${HOME}/.dotnet" "${HOME}/.local/bin" "${HOME}/bin" $path)
+
+# dotnet
+export DOTNET_ROOT="${HOME}/.dotnet"
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # nvm
 export NVM_DIR="${HOME}/.nvm"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,7 +1,7 @@
 ZDOTDIR="${ZDOTDIR:-$HOME}"
 
 typeset -U path
-path=("${HOME}/.dotnet" "${HOME}/.local/bin" "${HOME}/bin" $path)
+path=("${HOME}/.dotnet" "${HOME}/.dotnet/tools" "${HOME}/.local/bin" "${HOME}/bin" $path)
 
 # dotnet
 export DOTNET_ROOT="${HOME}/.dotnet"

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -42,6 +42,18 @@ else
   echo "Neovim already installed: $(nvim --version | head -1)"
 fi
 
+# ── .NET SDK (for csharp_ls / fsautocomplete LSP servers) ──────────
+export DOTNET_ROOT="${HOME}/.dotnet"
+export PATH="${DOTNET_ROOT}:${PATH}"
+
+if ! command -v dotnet &>/dev/null; then
+  echo "Installing .NET SDK (latest LTS)..."
+  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel LTS
+  echo ".NET SDK installed: $(dotnet --version)"
+else
+  echo ".NET SDK already installed: $(dotnet --version)"
+fi
+
 # ── nvm (Node Version Manager) ─────────────────────────────────────
 if [[ ! -d "${HOME}/.nvm" ]]; then
   echo "Installing nvm..."
@@ -166,5 +178,6 @@ echo "  oh-my-posh         → $(command -v oh-my-posh 2>/dev/null || echo 'not 
 echo "  gh                 → $(command -v gh 2>/dev/null || echo 'not found')"
 echo "  copilot            → $(command -v copilot 2>/dev/null || echo 'not found')"
 echo "  nvm                → ${HOME}/.nvm"
+echo "  dotnet             → $(command -v dotnet 2>/dev/null || echo 'not found')"
 echo ""
 echo "Restart your terminal or run: exec zsh"

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -48,7 +48,7 @@ export PATH="${DOTNET_ROOT}:${PATH}"
 
 if ! command -v dotnet &>/dev/null; then
   echo "Installing .NET SDK (latest LTS)..."
-  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel LTS
+  curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel LTS --install-dir "${DOTNET_ROOT}"
   echo ".NET SDK installed: $(dotnet --version)"
 else
   echo ".NET SDK already installed: $(dotnet --version)"


### PR DESCRIPTION
## Problem

Mason LSP servers `csharp_ls` and `fsautocomplete` fail to install because the .NET SDK is missing on fresh Linux/WSL installs.

## Changes

| File | Change |
|------|--------|
| `zsh/init.sh` | Install .NET SDK (LTS) via `dotnet-install.sh` to `~/.dotnet` |
| `zsh/.zshrc` | Add `~/.dotnet` to `path` array, set `DOTNET_ROOT` and opt out of telemetry |
| `.github/copilot/agent.md` | Document both bootstrap scripts (`zsh/init.sh`, `win/init.ps1`) with full tool inventory and guidance for adding new dependencies |