### PR TITLE
refactor: move directory-specific instructions to file-scoped files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,62 +6,6 @@ Cross-platform dotfiles repository managing configurations for Neovim, PowerShel
 
 The `archive/` directory contains legacy configs that are no longer actively maintained. Focus work on the active top-level directories.
 
-## Neovim Configuration (`nvim/`)
-
-Cross-platform — works on both Windows (PowerShell) and Linux/WSL (ZSH). Built on **lazy.nvim** with a modular Lua architecture:
-
-- `init.lua` → bootstraps `lua/config/lazy.lua`
-- `lua/config/` — core settings split by concern:
-  - `lazy.lua` — lazy.nvim bootstrap and plugin spec loading
-  - `opts.lua` — editor options (indentation, search, clipboard, shell)
-  - `maps.lua` — global keybindings
-  - `auto.lua` — autocommands (format-on-save for ~15 filetypes)
-- `lua/plugins/` — one file per plugin concern (lsp, completion, ai, git, etc.)
-
-### Conventions
-
-- **Plugin files return a table** (or list of tables) per lazy.nvim spec format.
-- **Lazy load everything** — use `event`, `cmd`, `ft`, or `keys` to defer loading.
-- **Leader key categories** follow a mnemonic grouping:
-  - `<leader>l*` — LSP (format, rename, actions)
-  - `<leader>f*` — Find/browse (files, grep, buffers)
-  - `<leader>t*` — Testing (neotest)
-  - `<leader>a*` — AI (Copilot, CodeCompanion)
-  - `<leader>b*` — Buffers
-- **Format-on-save** is configured via `BufWritePre` autocommands in `auto.lua`. When adding a new filetype, add it to the existing pattern list there.
-- **LSP servers** are installed via Mason. The server list lives in `plugins/lsp.lua` inside the `ensure_installed` table.
-- **UI borders** use `'rounded'` style consistently (LSP hover, signature help, completion).
-- **Platform detection** — `opts.lua` detects Windows and configures PowerShell as the shell; on Linux/WSL it uses the system default. Preserve this cross-platform awareness when editing.
-
-## ZSH Configuration (`zsh/`)
-
-Modular ZSH setup for Linux/WSL using **Oh My Zsh** + **Oh My Posh** (material theme). Uses `ZDOTDIR` to load config directly from the repo — only `~/.zshenv` is needed in the home directory.
-
-- `.zshrc` — main config: Oh My Zsh framework, Oh My Posh prompt, sources modular files
-- `aliases.zsh`, `functions.zsh`, `keybindings.zsh`, `completions.zsh` — modular config files
-- `init.sh` — bootstrap script for fresh Linux/WSL installs
-
-### Conventions
-
-- **ZDOTDIR must be defaulted** at the top of `.zshrc` (e.g., `ZDOTDIR="${ZDOTDIR:-$HOME}"`) since it's used for all path construction.
-- **Use `add-zsh-hook`** instead of defining hook functions directly (e.g., `precmd`).
-- **Use single quotes for aliases** that reference variables to defer expansion to runtime.
-- **fzf functions** (`fd`, `fp`, `fdx`, `fdev`) mirror the PowerShell profile equivalents.
-- **`fdev`** uses `wt.exe` from WSL for Windows Terminal tab+split management.
-
-## PowerShell Profile (`powershell/`)
-
-- Uses **Oh My Posh** (Material theme) for prompt styling and **PSReadLine in Vi mode**.
-- Custom functions `fd`/`fdx`/`fp`/`fdev` use **fzf** for fuzzy directory navigation.
-- Aliases: `g` → git, `vim`/`vi` → nvim.
-- Sources a GitHub Copilot CLI script from the user's OneDrive Documents folder.
-
-## Windows Configuration (`win/`)
-
-- **`init.ps1`** — Bootstraps a Windows dev environment using **winget** (primary) and **Chocolatey** (fallback). Installs ~21 winget packages plus additional tools via choco, uv, npm, and gh.
-- **`.gitconfig`** — Short aliases for frequent operations (`a`, `c`, `d`, `s`, `b`, `l`) and composite aliases for workflows (`acp` = add all + commit + push). Diff/merge tool is **Meld**.
-- **`.ideavimrc`** — Vim keybindings for JetBrains IDEs. Shares some Neovim leader key categories (`<leader>f*` for find, `<leader>t*` for test) but adapts others for IDE-specific actions (e.g., `<leader>b*` is Build/Rebuild/Clean vs Buffers in Neovim).
-
 ## Deployment
 
 Configs are deployed by **symlinking** from this repo to their expected system locations. On Linux/WSL, `zsh/init.sh` handles bootstrap and symlinks. For Windows, symlink manually or adapt the pattern from `archive/symlinkers/`.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -14,4 +14,5 @@ Use **trunk-based development** against `master`. Never commit directly to `mast
 
 - Before pushing, merge `master` into the feature branch to keep it up to date
 - After addressing review feedback, commit and push the fixes, then reply to each comment thread
+- After every push to a PR, poll for new review feedback and address it iteratively until there are no unresolved comments
 - When creating PRs, include a summary table of changes and note any dependencies on other PRs

--- a/.github/instructions/nvim.instructions.md
+++ b/.github/instructions/nvim.instructions.md
@@ -1,0 +1,31 @@
+---
+description: 'Neovim configuration conventions'
+applyTo: 'nvim/**'
+---
+
+# Neovim Configuration
+
+Cross-platform — works on both Windows (PowerShell) and Linux/WSL (ZSH). Built on **lazy.nvim** with a modular Lua architecture:
+
+- `init.lua` → bootstraps `lua/config/lazy.lua`
+- `lua/config/` — core settings split by concern:
+  - `lazy.lua` — lazy.nvim bootstrap and plugin spec loading
+  - `opts.lua` — editor options (indentation, search, clipboard, shell)
+  - `maps.lua` — global keybindings
+  - `auto.lua` — autocommands (format-on-save for ~15 filetypes)
+- `lua/plugins/` — one file per plugin concern (lsp, completion, ai, git, etc.)
+
+## Conventions
+
+- **Plugin files return a table** (or list of tables) per lazy.nvim spec format.
+- **Lazy load everything** — use `event`, `cmd`, `ft`, or `keys` to defer loading.
+- **Leader key categories** follow a mnemonic grouping:
+  - `<leader>l*` — LSP (format, rename, actions)
+  - `<leader>f*` — Find/browse (files, grep, buffers)
+  - `<leader>t*` — Testing (neotest)
+  - `<leader>a*` — AI (Copilot, CodeCompanion)
+  - `<leader>b*` — Buffers
+- **Format-on-save** is configured via `BufWritePre` autocommands in `auto.lua`. When adding a new filetype, add it to the existing pattern list there.
+- **LSP servers** are installed via Mason. The server list lives in `plugins/lsp.lua` inside the `ensure_installed` table.
+- **UI borders** use `'rounded'` style consistently (LSP hover, signature help, completion).
+- **Platform detection** — `opts.lua` detects Windows and configures PowerShell as the shell; on Linux/WSL it uses the system default. Preserve this cross-platform awareness when editing.

--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -1,0 +1,11 @@
+---
+description: 'PowerShell profile conventions'
+applyTo: 'powershell/**'
+---
+
+# PowerShell Profile
+
+- Uses **Oh My Posh** (Material theme) for prompt styling and **PSReadLine in Vi mode**.
+- Custom functions `fd`/`fdx`/`fp`/`fdev` use **fzf** for fuzzy directory navigation.
+- Aliases: `g` → git, `vim`/`vi` → nvim.
+- Sources a GitHub Copilot CLI script from the user's OneDrive Documents folder.

--- a/.github/instructions/win.instructions.md
+++ b/.github/instructions/win.instructions.md
@@ -1,0 +1,10 @@
+---
+description: 'Windows configuration and bootstrap'
+applyTo: 'win/**'
+---
+
+# Windows Configuration
+
+- **`init.ps1`** — Bootstraps a Windows dev environment using **winget** (primary) and **Chocolatey** (fallback). Installs ~21 winget packages plus additional tools via choco, uv, npm, and gh. Does not currently install .NET SDK — add via winget if needed.
+- **`.gitconfig`** — Short aliases for frequent operations (`a`, `c`, `d`, `s`, `b`, `l`) and composite aliases for workflows (`acp` = add all + commit + push). Diff/merge tool is **Meld**.
+- **`.ideavimrc`** — Vim keybindings for JetBrains IDEs. Shares some Neovim leader key categories (`<leader>f*` for find, `<leader>t*` for test) but adapts others for IDE-specific actions (e.g., `<leader>b*` is Build/Rebuild/Clean vs Buffers in Neovim).

--- a/.github/instructions/zsh.instructions.md
+++ b/.github/instructions/zsh.instructions.md
@@ -1,0 +1,39 @@
+---
+description: 'ZSH configuration conventions and bootstrap'
+applyTo: 'zsh/**'
+---
+
+# ZSH Configuration
+
+Modular ZSH setup for Linux/WSL using **Oh My Zsh** + **Oh My Posh** (material theme). Uses `ZDOTDIR` to load config directly from the repo — only `~/.zshenv` is needed in the home directory.
+
+- `.zshrc` — main config: Oh My Zsh framework, Oh My Posh prompt, sources modular files
+- `aliases.zsh`, `functions.zsh`, `keybindings.zsh`, `completions.zsh` — modular config files
+- `init.sh` — bootstrap script for fresh Linux/WSL installs
+
+## Conventions
+
+- **ZDOTDIR must be defaulted** at the top of `.zshrc` (e.g., `ZDOTDIR="${ZDOTDIR:-$HOME}"`) since it's used for all path construction.
+- **Use `add-zsh-hook`** instead of defining hook functions directly (e.g., `precmd`).
+- **Use single quotes for aliases** that reference variables to defer expansion to runtime.
+- **fzf functions** (`fd`, `fp`, `fdx`, `fdev`) mirror the PowerShell profile equivalents.
+- **`fdev`** uses `wt.exe` from WSL for Windows Terminal tab+split management.
+
+## Bootstrap (`init.sh`)
+
+Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
+
+| Category | Tools |
+|----------|-------|
+| apt packages | zsh, fzf, ripgrep, curl, wget, git, build-essential, unzip |
+| Neovim | Latest stable from GitHub releases (supports `--force` for upgrades) |
+| .NET SDK | Latest LTS via `dotnet-install.sh` to `~/.dotnet` (needed for csharp_ls, fsautocomplete) |
+| nvm + Node | nvm + Node LTS (needed for Copilot CLI, Mason LSP servers) |
+| Oh My Zsh | Framework + zsh-syntax-highlighting, zsh-autosuggestions plugins |
+| GitHub CLI | `gh` from official apt repo |
+| Copilot CLI | `@github/copilot` via npm |
+| Oh My Posh | Prompt theme engine to `~/.local/bin` |
+
+Also configures: `ZDOTDIR` via `~/.zshenv`, nvim config symlink, default shell to zsh.
+
+When adding a new tool dependency (e.g., a new Mason LSP server that needs a runtime), add the install step to this script and ensure the runtime's bin directory is on PATH in both `init.sh` and `.zshrc`.


### PR DESCRIPTION
## Problem

`copilot-instructions.md` loaded 68 lines of directory-specific conventions into every Copilot interaction, even when only editing one area. Bootstrap script docs in `agent.md` also loaded unconditionally.

## Solution

Use GitHub Copilot's `.github/instructions/*.instructions.md` with `applyTo` globs to scope instructions to relevant files.

## Changes

| File | Change |
|------|--------|
| `copilot-instructions.md` | Slimmed from 68 → 11 lines (repo overview + deployment only) |
| `instructions/nvim.instructions.md` | Neovim conventions, scoped to `nvim/**` |
| `instructions/zsh.instructions.md` | ZSH conventions + bootstrap docs, scoped to `zsh/**` |
| `instructions/powershell.instructions.md` | PowerShell info, scoped to `powershell/**` |
| `instructions/win.instructions.md` | Windows config info, scoped to `win/**` |
| `agent.md` | Removed bootstrap section (moved to zsh/win instructions), added feedback polling rule |

No content was lost — everything was relocated to file-scoped instructions.