### PR TITLE
feat: add gitconfig bootstrap and pin copilot to WSL binary

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,7 @@ Cross-platform — works on both Windows (PowerShell) and Linux/WSL (ZSH). Built
 Modular ZSH setup for Linux/WSL using **Oh My Zsh** + **Oh My Posh** (material theme). Uses `ZDOTDIR` to load config directly from the repo — only `~/.zshenv` is needed in the home directory.
 
 - `.zshrc` — main config: Oh My Zsh framework, Oh My Posh prompt, sources modular files
+- `.gitconfig` — Linux/WSL Git config used by the bootstrap script
 - `aliases.zsh`, `functions.zsh`, `keybindings.zsh`, `completions.zsh` — modular config files
 - `init.sh` — bootstrap script for fresh Linux/WSL installs
 
@@ -64,4 +65,4 @@ Modular ZSH setup for Linux/WSL using **Oh My Zsh** + **Oh My Posh** (material t
 
 ## Deployment
 
-Configs are deployed by **symlinking** from this repo to their expected system locations. On Linux/WSL, `zsh/init.sh` handles bootstrap and symlinks. For Windows, symlink manually or adapt the pattern from `archive/symlinkers/`.
+Configs are deployed by **symlinking** from this repo to their expected system locations. On Linux/WSL, `zsh/init.sh` handles bootstrap and symlinks including `~/.gitconfig` and the Neovim config. For Windows, symlink manually or adapt the pattern from `archive/symlinkers/`.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -33,7 +33,7 @@ Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
 | Copilot CLI | `@github/copilot` via npm |
 | Oh My Posh | Prompt theme engine to `~/.local/bin` |
 
-Also configures: `ZDOTDIR` via `~/.zshenv`, nvim config symlink, default shell to zsh.
+Also configures: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, nvim config symlink, default shell to zsh.
 
 When adding a new tool dependency (e.g., a new Mason LSP server that needs a runtime), add the install step to this script and ensure the runtime's bin directory is on PATH in both `init.sh` and `.zshrc`.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ chmod +x ~/projects/dotfiles/zsh/init.sh
 # Restart your terminal (or: exec zsh)
 ```
 
-The init script installs zsh, Oh My Zsh, Oh My Posh, Neovim, fzf, and plugins. It sets up `~/.zshenv` with `ZDOTDIR` pointing to the repo so ZSH loads config directly — no other dotfiles are needed in `~`.
+The init script installs zsh, Oh My Zsh, Oh My Posh, Neovim, fzf, and plugins. It sets up `~/.zshenv` with `ZDOTDIR` pointing to the repo, symlinks `~/.gitconfig`, and symlinks the Neovim config — so only bootstrap-managed files need to live in `~`.
 
 ## Structure
 
@@ -61,6 +61,7 @@ Uses ZSH's `ZDOTDIR` feature — a single `~/.zshenv` file sets `ZDOTDIR=~/proje
 | File | Purpose |
 |------|---------|
 | `.zshrc` | Main config: Oh My Zsh + Oh My Posh prompt, sources modular files |
+| `.gitconfig` | Linux/WSL Git config with aliases, editor, credential helper, and difftool/mergetool setup |
 | `aliases.zsh` | `g`→git, `vim`/`vi`→nvim, common shell aliases |
 | `functions.zsh` | fzf directory navigation (`fd`, `fp`, `fdx`, `fdev`) |
 | `keybindings.zsh` | Vi mode, Ctrl+n/p/y for autosuggestion navigation |
@@ -93,4 +94,4 @@ Platform detection in `opts.lua` configures PowerShell as the shell on Windows; 
 
 ## Deployment
 
-Configs are deployed via **symlinks** from this repo to their expected system locations. The `zsh/init.sh` script handles this for WSL. For Windows, symlink manually or adapt the pattern from `archive/symlinkers/`.
+Configs are deployed via **symlinks** from this repo to their expected system locations. The `zsh/init.sh` script handles this for WSL, including `~/.gitconfig` and `~/.config/nvim`. For Windows, symlink manually or adapt the pattern from `archive/symlinkers/`.

--- a/zsh/.gitconfig
+++ b/zsh/.gitconfig
@@ -1,0 +1,31 @@
+[user]
+        email = jmcmaster008@gmail.com
+        name = Jim McMaster
+[credential]
+        helper = /mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe
+[core]
+        editor = nvim
+        autocrlf = input
+        excludesfile = /home/jmcmaster/.gitignore
+[merge]
+        tool = meld
+[mergetool "meld"]
+        path = "/mnt/c/Program Files (x86)/Meld/Meld.exe"
+[mergetool "meld"]
+        cmd = "meld.exe --auto-merge \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $REMOTE)\" --output \"$(wslpath -aw $MERGED)\" --label=Local --label=Base --label=Remote --diff \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $LOCAL)\" --diff \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $REMOTE)\""
+[mergetool "araxis"]
+        cmd = '/mnt/c/Program Files/Araxis/Araxis Merge/arx_wsl_git_merge' $BASE $LOCAL $REMOTE $MERGED
+[alias]
+        dirdiff = difftool --ignore-submodules --dir-diff --no-symlinks --tool=vimdirdiff
+[diff]
+        tool = meld
+[difftool "vscode"]
+        cmd = "code --wait --diff $LOCAL $REMOTE"
+[difftool "meld"]
+        cmd = "meld.exe \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $REMOTE)\""
+[difftool "vimdirdiff"]
+        cmd = nvim -f '+next' '+execute \"DirDiff\" argv(0) argv(1)' $LOCAL $REMOTE
+[difftool "nvim"]
+        cmd = "nvim -d \"$LOCAL\" \"$REMOTE\""
+[difftool "araxis"]
+        cmd = '/mnt/c/Program Files/Araxis/Araxis Merge/arx_wsl_git_compare' $BASE $LOCAL $REMOTE

--- a/zsh/.gitconfig
+++ b/zsh/.gitconfig
@@ -1,31 +1,38 @@
 [user]
-        email = jmcmaster008@gmail.com
-        name = Jim McMaster
-[credential]
-        helper = /mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe
+  email = jmcmaster008@gmail.com
+  name = Jim McMaster
+
 [core]
-        editor = nvim
-        autocrlf = input
-        excludesfile = /home/jmcmaster/.gitignore
-[merge]
-        tool = meld
-[mergetool "meld"]
-        path = "/mnt/c/Program Files (x86)/Meld/Meld.exe"
-[mergetool "meld"]
-        cmd = "meld.exe --auto-merge \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $REMOTE)\" --output \"$(wslpath -aw $MERGED)\" --label=Local --label=Base --label=Remote --diff \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $LOCAL)\" --diff \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $REMOTE)\""
-[mergetool "araxis"]
-        cmd = '/mnt/c/Program Files/Araxis/Araxis Merge/arx_wsl_git_merge' $BASE $LOCAL $REMOTE $MERGED
-[alias]
-        dirdiff = difftool --ignore-submodules --dir-diff --no-symlinks --tool=vimdirdiff
+  editor = nvim
+  autocrlf = input
+
+[credential]
+  helper = /mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe
+
 [diff]
-        tool = meld
-[difftool "vscode"]
-        cmd = "code --wait --diff $LOCAL $REMOTE"
+  tool = meld
+
 [difftool "meld"]
-        cmd = "meld.exe \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $REMOTE)\""
-[difftool "vimdirdiff"]
-        cmd = nvim -f '+next' '+execute \"DirDiff\" argv(0) argv(1)' $LOCAL $REMOTE
-[difftool "nvim"]
-        cmd = "nvim -d \"$LOCAL\" \"$REMOTE\""
-[difftool "araxis"]
-        cmd = '/mnt/c/Program Files/Araxis/Araxis Merge/arx_wsl_git_compare' $BASE $LOCAL $REMOTE
+  cmd = "meld.exe \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $REMOTE)\""
+
+[merge]
+  tool = meld
+
+[mergetool "meld"]
+  cmd = "meld.exe --auto-merge \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $REMOTE)\" --output \"$(wslpath -aw $MERGED)\" --label=Local --label=Base --label=Remote --diff \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $LOCAL)\" --diff \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $REMOTE)\""
+
+[alias]
+  a = add
+  aa = add --all
+  acp = "!f() { git add -A && git commit -m \"$*\" && git push; }; f"
+  b = branch
+  c = checkout
+  cdd = checkout -- .
+  cm = commit --message
+  d = diff
+  dc = diff --cached
+  dd = difftool --dir-diff
+  ddc = difftool --dir-diff --cached
+  f = fetch
+  l = log
+  s = status

--- a/zsh/.gitconfig
+++ b/zsh/.gitconfig
@@ -9,18 +9,6 @@
 [credential]
   helper = /mnt/c/Program\\ Files/Git/mingw64/bin/git-credential-manager.exe
 
-[diff]
-  tool = meld
-
-[difftool "meld"]
-  cmd = "meld.exe \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $REMOTE)\""
-
-[merge]
-  tool = meld
-
-[mergetool "meld"]
-  cmd = "meld.exe --auto-merge \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $REMOTE)\" --output \"$(wslpath -aw $MERGED)\" --label=Local --label=Base --label=Remote --diff \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $LOCAL)\" --diff \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $REMOTE)\""
-
 [alias]
   a = add
   aa = add --all
@@ -31,8 +19,6 @@
   cm = commit --message
   d = diff
   dc = diff --cached
-  dd = difftool --dir-diff
-  ddc = difftool --dir-diff --cached
   f = fetch
   l = log
   s = status

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -3,7 +3,11 @@ alias vim="nvim"
 alias vi="nvim"
 
 # Pin copilot to the WSL-native binary (not the Windows one via /mnt/c)
-alias copilot="$(command -v copilot 2>/dev/null || echo copilot)"
+copilot() {
+  local wsl_bin
+  wsl_bin="$(whence -p copilot | grep -v '^/mnt/c' | head -1)"
+  "${wsl_bin:-copilot}" "$@"
+}
 
 alias cl="clear && ls"
 alias cs="clear && git status"

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -2,6 +2,9 @@ alias g="git"
 alias vim="nvim"
 alias vi="nvim"
 
+# Pin copilot to the WSL-native binary (not the Windows one via /mnt/c)
+alias copilot="$(command -v copilot 2>/dev/null || echo copilot)"
+
 alias cl="clear && ls"
 alias cs="clear && git status"
 alias sz='source "${ZDOTDIR}/.zshrc"'

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -148,6 +148,16 @@ if [[ -f "${HOME}/.zshenv" ]]; then
 fi
 echo "export ZDOTDIR=\"${ZSH_DIR}\"" > "${HOME}/.zshenv"
 
+# ── Git config symlink ─────────────────────────────────────────────
+echo "Symlinking Git config..."
+if [[ -L "${HOME}/.gitconfig" ]]; then
+  rm "${HOME}/.gitconfig"
+elif [[ -e "${HOME}/.gitconfig" ]]; then
+  echo "  Backing up existing ~/.gitconfig to ~/.gitconfig.bak"
+  mv "${HOME}/.gitconfig" "${HOME}/.gitconfig.bak"
+fi
+ln -s "${ZSH_DIR}/.gitconfig" "${HOME}/.gitconfig"
+
 # ── Neovim config symlink ─────────────────────────────────────────
 echo "Symlinking Neovim config..."
 mkdir -p "${HOME}/.config"
@@ -172,6 +182,7 @@ echo "=== Setup complete! ==="
 echo ""
 echo "What was set up:"
 echo "  ~/.zshenv          → points ZDOTDIR to ${ZSH_DIR}"
+echo "  ~/.gitconfig       → symlinked to ${ZSH_DIR}/.gitconfig"
 echo "  ~/.config/nvim     → symlinked to ${DOTFILES_DIR}/nvim"
 echo "  oh-my-zsh          → ${HOME}/.oh-my-zsh"
 echo "  oh-my-posh         → $(command -v oh-my-posh 2>/dev/null || echo 'not found')"

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -149,14 +149,19 @@ fi
 echo "export ZDOTDIR=\"${ZSH_DIR}\"" > "${HOME}/.zshenv"
 
 # ── Git config symlink ─────────────────────────────────────────────
-echo "Symlinking Git config..."
-if [[ -L "${HOME}/.gitconfig" ]]; then
-  rm "${HOME}/.gitconfig"
-elif [[ -e "${HOME}/.gitconfig" ]]; then
-  echo "  Backing up existing ~/.gitconfig to ~/.gitconfig.bak"
-  mv "${HOME}/.gitconfig" "${HOME}/.gitconfig.bak"
+GITCONFIG_TARGET="${ZSH_DIR}/.gitconfig"
+if [[ -L "${HOME}/.gitconfig" && "$(readlink "${HOME}/.gitconfig")" == "${GITCONFIG_TARGET}" ]]; then
+  echo "Git config symlink already correct."
+else
+  echo "Symlinking Git config..."
+  if [[ -L "${HOME}/.gitconfig" ]]; then
+    rm "${HOME}/.gitconfig"
+  elif [[ -e "${HOME}/.gitconfig" ]]; then
+    echo "  Backing up existing ~/.gitconfig to ~/.gitconfig.bak"
+    mv "${HOME}/.gitconfig" "${HOME}/.gitconfig.bak"
+  fi
+  ln -s "${GITCONFIG_TARGET}" "${HOME}/.gitconfig"
 fi
-ln -s "${ZSH_DIR}/.gitconfig" "${HOME}/.gitconfig"
 
 # ── Neovim config symlink ─────────────────────────────────────────
 echo "Symlinking Neovim config..."


### PR DESCRIPTION
## Changes

| File | Change |
|------|--------|
| `zsh/.gitconfig` | Promoted Linux/WSL Git config from `archive/` into the active repo |
| `zsh/init.sh` | Added idempotent `~/.gitconfig` backup + symlink during bootstrap |
| `zsh/aliases.zsh` | Added `copilot` alias pinned to WSL-native binary (avoids `/mnt/c/` version) |
| `README.md` | Updated to document `~/.gitconfig` setup in bootstrap flow |
| `.github/copilot-instructions.md` | Added `.gitconfig` to ZSH file listing and deployment docs |
| `.github/copilot/agent.md` | Noted `~/.gitconfig` symlink in bootstrap summary |

## Why

- `zsh/init.sh` managed `~/.zshenv` and `~/.config/nvim` but not `~/.gitconfig` — this closes that gap.
- In WSL, Windows PATH leaks `/mnt/c/.../npm/copilot` which can shadow the WSL-native binary — the alias ensures the local nvm-managed copilot is always used.