### PR TITLE
feat: set Ubuntu-24.04 as default Windows Terminal profile

### DIFF
--- a/wt/settings.json
+++ b/wt/settings.json
@@ -30,7 +30,7 @@
     "centerOnLaunch": true,
     "copyFormatting": "none",
     "copyOnSelect": false,
-    "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+    "defaultProfile": "{338bd38a-90e8-5960-9bca-f5958ac99ba9}",
     "initialCols": 120,
     "initialRows": 40,
     "keybindings": 
@@ -359,6 +359,12 @@
         },
         "list": 
         [
+            {
+                "guid": "{338bd38a-90e8-5960-9bca-f5958ac99ba9}",
+                "hidden": false,
+                "name": "Ubuntu-24.04",
+                "source": "Windows.Terminal.Wsl"
+            },
             {
                 "font": 
                 {


### PR DESCRIPTION
## Changes

- Set `defaultProfile` to Ubuntu-24.04 WSL distro (`{338bd38a-90e8-5960-9bca-f5958ac99ba9}`)
- Add explicit Ubuntu-24.04 profile entry with `source: "Windows.Terminal.Wsl"`

Previously defaulted to PowerShell (`{574e775e-4f2a-5b96-ac1e-a2962a402336}`).