### PR TITLE
feat(init): add apt upgrade, Azure CLI, and simplify WT config

### DIFF
--- a/wt/settings.json
+++ b/wt/settings.json
@@ -349,22 +349,14 @@
             "colorScheme": "GitHub Dark",
             "font": 
             {
-                "cellHeight": "1.7",
-                "cellWidth": "0.7",
-                "face": "FiraCode Nerd Font",
-                "size": 10
+                "face": "FiraCode Nerd Font"
             },
-            "padding": "0",
             "scrollbarState": "hidden"
         },
         "list": 
         [
             {
                 "commandline": "C:\\WINDOWS\\system32\\wsl.exe -d Ubuntu-24.04",
-                "font": 
-                {
-                    "size": 9
-                },
                 "guid": "{f1fcf712-c88e-4fa6-9b16-de9ef0e304c0}",
                 "hidden": false,
                 "icon": "ms-appx:///ProfileIcons/{9acb9455-ca41-5af7-950f-6bca1bc9722f}.png",
@@ -373,10 +365,6 @@
                 "startingDirectory": "~"
             },
             {
-                "font": 
-                {
-                    "size": 9
-                },
                 "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
                 "hidden": false,
                 "name": "PowerShell",

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -10,9 +10,13 @@ echo "  Dotfiles: ${DOTFILES_DIR}"
 echo "  ZSH dir:  ${ZSH_DIR}"
 echo ""
 
+# ── System update ──────────────────────────────────────────────────
+echo "Updating and upgrading system packages..."
+sudo apt update -y && sudo apt upgrade -y
+
 # ── Prerequisites via apt ──────────────────────────────────────────
 echo "Installing apt packages..."
-sudo apt update -y && sudo apt install -y \
+sudo apt install -y \
   zsh \
   fzf \
   ripgrep \
@@ -103,11 +107,20 @@ if ! command -v gh &>/dev/null; then
   ARCH=$(dpkg --print-architecture)
   echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     | sudo tee /etc/apt/sources.list.d/github-cli-stable.list > /dev/null
-  sudo apt update -y && sudo apt install gh -y
+  sudo apt install gh -y
   rm -f /tmp/githubcli-archive-keyring.gpg
   echo "GitHub CLI installed: $(gh --version | head -1)"
 else
   echo "GitHub CLI already installed: $(gh --version | head -1)"
+fi
+
+# ── Azure CLI ──────────────────────────────────────────────────────
+if ! az version &>/dev/null; then
+  echo "Installing Azure CLI..."
+  curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  echo "Azure CLI installed: $(az version | head -1)"
+else
+  echo "Azure CLI already installed: $(az version | head -1)"
 fi
 
 # ── GitHub Copilot CLI ─────────────────────────────────────────────
@@ -192,6 +205,7 @@ echo "  ~/.config/nvim     → symlinked to ${DOTFILES_DIR}/nvim"
 echo "  oh-my-zsh          → ${HOME}/.oh-my-zsh"
 echo "  oh-my-posh         → $(command -v oh-my-posh 2>/dev/null || echo 'not found')"
 echo "  gh                 → $(command -v gh 2>/dev/null || echo 'not found')"
+echo "  az                 → $(command -v az 2>/dev/null || echo 'not found')"
 echo "  copilot            → $(command -v copilot 2>/dev/null || echo 'not found')"
 echo "  nvm                → ${HOME}/.nvm"
 echo "  dotnet             → $(command -v dotnet 2>/dev/null || echo 'not found')"

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -11,8 +11,11 @@ echo "  ZSH dir:  ${ZSH_DIR}"
 echo ""
 
 # ── System update ──────────────────────────────────────────────────
-echo "Updating and upgrading system packages..."
-sudo DEBIAN_FRONTEND=noninteractive apt update -y && sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
+sudo DEBIAN_FRONTEND=noninteractive apt update -y
+if [[ " $* " == *" --upgrade "* ]]; then
+  echo "Upgrading system packages (--upgrade flag set)..."
+  sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
+fi
 
 # ── Prerequisites via apt ──────────────────────────────────────────
 echo "Installing apt packages..."
@@ -117,7 +120,7 @@ fi
 # ── Azure CLI ──────────────────────────────────────────────────────
 if ! command -v az &>/dev/null; then
   echo "Installing Azure CLI..."
-  curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
   echo "Azure CLI installed: $(az version --query '\"azure-cli\"' -o tsv)"
 else
   echo "Azure CLI already installed: $(az version --query '\"azure-cli\"' -o tsv)"

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -12,7 +12,7 @@ echo ""
 
 # ── System update ──────────────────────────────────────────────────
 echo "Updating and upgrading system packages..."
-sudo apt update -y && sudo apt upgrade -y
+sudo DEBIAN_FRONTEND=noninteractive apt update -y && sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 
 # ── Prerequisites via apt ──────────────────────────────────────────
 echo "Installing apt packages..."
@@ -107,7 +107,7 @@ if ! command -v gh &>/dev/null; then
   ARCH=$(dpkg --print-architecture)
   echo "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     | sudo tee /etc/apt/sources.list.d/github-cli-stable.list > /dev/null
-  sudo apt install gh -y
+  sudo apt update -y && sudo apt install gh -y
   rm -f /tmp/githubcli-archive-keyring.gpg
   echo "GitHub CLI installed: $(gh --version | head -1)"
 else
@@ -115,12 +115,12 @@ else
 fi
 
 # ── Azure CLI ──────────────────────────────────────────────────────
-if ! az version &>/dev/null; then
+if ! command -v az &>/dev/null; then
   echo "Installing Azure CLI..."
   curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-  echo "Azure CLI installed: $(az version | head -1)"
+  echo "Azure CLI installed: $(az version --query '\"azure-cli\"' -o tsv)"
 else
-  echo "Azure CLI already installed: $(az version | head -1)"
+  echo "Azure CLI already installed: $(az version --query '\"azure-cli\"' -o tsv)"
 fi
 
 # ── GitHub Copilot CLI ─────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### `zsh/init.sh`
- **Add system update step** — `apt update` runs unconditionally; `apt upgrade` is opt-in via `--upgrade` flag (uses `DEBIAN_FRONTEND=noninteractive` with dpkg conffile options)
- **Add Azure CLI install** via Microsoft's official script (`curl -fsSL`), using `command -v` for existence check and `az version --query` for clean version output
- **GitHub CLI section** retains its own `apt update` since it adds a new apt source inline before installing

### `wt/settings.json`
- **Remove font size/padding overrides** — drop `cellHeight`, `cellWidth`, `size`, and `padding` from defaults and per-profile font size overrides from Ubuntu and PowerShell profiles to rely on Windows Terminal defaults

### Flags
| Flag | Effect |
|------|--------|
| `--force` | Reinstall Neovim (existing) |
| `--upgrade` | Run `apt upgrade` during bootstrap (new) |