### PR TITLE
feat(wt): add font sizing and reorder keybindings

### DIFF
--- a/wt/settings.json
+++ b/wt/settings.json
@@ -57,19 +57,19 @@
         },
         {
             "id": null,
+            "keys": "ctrl+numpad_minus"
+        },
+        {
+            "id": null,
             "keys": "alt+right"
         },
         {
             "id": null,
-            "keys": "ctrl+numpad_minus"
+            "keys": "ctrl+comma"
         },
         {
             "id": "Terminal.FindText",
             "keys": "ctrl+shift+f"
-        },
-        {
-            "id": null,
-            "keys": "ctrl+comma"
         },
         {
             "id": "Terminal.ClosePane",
@@ -349,7 +349,10 @@
             "colorScheme": "GitHub Dark",
             "font": 
             {
-                "face": "FiraCode Nerd Font"
+                "cellHeight": "1.7",
+                "cellWidth": "0.7",
+                "face": "FiraCode Nerd Font",
+                "size": 9
             },
             "scrollbarState": "hidden"
         },

--- a/wt/settings.json
+++ b/wt/settings.json
@@ -349,8 +349,8 @@
             "colorScheme": "GitHub Dark",
             "font": 
             {
-                "cellHeight": "1.7",
-                "cellWidth": "0.7",
+                "cellHeight": 1.7,
+                "cellWidth": 0.7,
                 "face": "FiraCode Nerd Font",
                 "size": 9
             },


### PR DESCRIPTION
## Changes

- **Font settings**: Add \cellHeight\ (1.7), \cellWidth\ (0.7), and \size\ (9) to the default Windows Terminal profile for tighter, more compact text rendering.
- **Keybindings**: Reorder unbound keybinding entries for consistency (no functional change).