### PR TITLE
feat(mac): add macOS ZSH config and iTerm2 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Windows-focused dotfiles managing configurations for Neovim, PowerShell, ZSH (WSL), Windows Terminal, Git, and IdeaVim.
+Cross-platform dotfiles managing configurations for Neovim, PowerShell (Windows), ZSH (WSL/Linux), macOS (iTerm2), Windows Terminal, Git, and IdeaVim.
 
 ## Quick Start
 
@@ -36,17 +36,79 @@ chmod +x ~/projects/dotfiles/zsh/init.sh
 
 The init script installs zsh, Oh My Zsh, Oh My Posh, Neovim, fzf, and plugins. It sets up `~/.zshenv` with `ZDOTDIR` pointing to the repo, symlinks `~/.gitconfig`, and symlinks the Neovim config — so only bootstrap-managed files need to live in `~`.
 
+### macOS (iTerm2 + ZSH)
+
+```bash
+# Clone the repo
+git clone https://github.com/jcmcmaster/dotfiles ~/projects/dotfiles
+
+# Run the bootstrap script
+chmod +x ~/projects/dotfiles/mac/init.sh
+~/projects/dotfiles/mac/init.sh
+
+# Restart your terminal (or: exec zsh)
+```
+
+The init script installs Homebrew packages, Oh My Zsh, Oh My Posh, Neovim, fzf, and plugins. It sets up `~/.zshenv` with `ZDOTDIR` pointing to `mac/`, symlinks `~/.gitconfig`, and symlinks the Neovim config.
+
+After running init, import the iTerm2 profile:
+1. **Preferences → Profiles → Other Actions → Import JSON Profiles** → select `mac/iterm2/Default.json`
+2. Set the imported profile as default.
+
 ## Structure
 
 | Directory | Purpose |
 |-----------|---------|
 | `nvim/` | Neovim config (lazy.nvim, Lua, cross-platform) |
+| `mac/` | macOS ZSH config + iTerm2 profile (Oh My Zsh, Oh My Posh, fzf) |
 | `powershell/` | PowerShell profile (Oh My Posh, PSReadLine vi mode, fzf) |
 | `zsh/` | ZSH config for WSL (Oh My Zsh + Oh My Posh, vi mode, fzf) |
 | `win/` | Windows init script, `.gitconfig`, `.ideavimrc` |
 | `wt/` | Windows Terminal settings |
 | `keyboard/` | QMK keyboard layout |
 | `archive/` | Legacy Linux configs (no longer actively maintained) |
+
+## Mac Configuration (`mac/`)
+
+Modular ZSH setup for macOS using **Oh My Zsh** + **Oh My Posh** (material theme), identical in structure to `zsh/`.
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `.zshrc` | Main config: Homebrew PATH, Oh My Zsh + Oh My Posh, sources modular files |
+| `.gitconfig` | macOS Git config (same aliases as WSL, uses `osxkeychain` credential helper) |
+| `aliases.zsh` | `g`→git, `vim`/`vi`→nvim, `owd`→`open .`, `brew-up` for updates |
+| `functions.zsh` | fzf directory navigation (`fd`, `fp`, `fdx`, `fdev`) |
+| `keybindings.zsh` | Vi mode, Ctrl+n/p/y for autosuggestion navigation |
+| `completions.zsh` | dotnet CLI + GitHub Copilot CLI completions |
+| `init.sh` | Bootstrap script (Homebrew, tools, Oh My Zsh, symlinks) |
+| `iterm2/` | iTerm2 color scheme and importable profile |
+
+### Key functions
+
+- **`fd [path] [depth]`** — Fuzzy find a directory and `cd` into it
+- **`fp`** — Fuzzy find in `~/projects` and `cd` into it
+- **`fdx`** — Fuzzy find in `~/Exercism` and `cd` into it
+- **`fdev [path] [depth] [name]`** — Fuzzy find a directory, then open an iTerm2 tab with a vertical split running nvim (mirrors the PowerShell and WSL `fdev` function)
+
+### iTerm2 Config (`mac/iterm2/`)
+
+| File | Purpose |
+|------|---------|
+| `GitHub Dark.itermcolors` | GitHub Dark color scheme (import via Preferences → Profiles → Colors → Color Presets → Import) |
+| `Default.json` | Full iTerm2 profile: FiraCode Nerd Font, GitHub Dark, 120×40 window, all key bindings from Windows Terminal translated |
+
+**Key bindings** mirror Windows Terminal exactly:
+- `shift+enter` → send ESC+Enter (useful in Neovim)
+- `ctrl+shift+t` → new tab
+- `ctrl+shift+w` → close pane
+- `ctrl+home/end/pgup/pgdn` → move focus between panes
+- `ctrl+shift+pgdn/pgup/home/end` → split pane down/up/left/right
+- `alt+home/end` → previous/next tab
+- `alt+shift+pgup/pgdn/home/end` → scroll up/down page/top/bottom
+
+> **Mac keyboard note**: Home/End/PgUp/PgDn require Fn+arrows on laptop keyboards.
 
 ## ZSH Configuration (`zsh/`)
 

--- a/mac/.gitconfig
+++ b/mac/.gitconfig
@@ -1,0 +1,24 @@
+[user]
+  email = jmcmaster008@gmail.com
+  name = Jim McMaster
+
+[core]
+  editor = nvim
+  autocrlf = input
+
+[credential]
+  helper = osxkeychain
+
+[alias]
+  a = add
+  aa = add --all
+  acp = "!f() { git add -A && git commit -m \"$*\" && git push; }; f"
+  b = branch
+  c = checkout
+  cdd = checkout -- .
+  cm = commit --message
+  d = diff
+  dc = diff --cached
+  f = fetch
+  l = log
+  s = status

--- a/mac/.zshrc
+++ b/mac/.zshrc
@@ -1,0 +1,47 @@
+ZDOTDIR="${ZDOTDIR:-$HOME}"
+
+typeset -U path
+path=("/opt/homebrew/bin" "/opt/homebrew/sbin" "${HOME}/.dotnet" "${HOME}/.dotnet/tools" "${HOME}/.local/bin" "${HOME}/bin" $path)
+
+# Homebrew
+export HOMEBREW_PREFIX="/opt/homebrew"
+
+# dotnet
+export DOTNET_ROOT="${HOME}/.dotnet"
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# nvm
+export NVM_DIR="${HOME}/.nvm"
+[ -s "${NVM_DIR}/nvm.sh" ] && source "${NVM_DIR}/nvm.sh"
+
+export HISTFILE="${ZDOTDIR}/.zsh_history"
+export HISTSIZE=10000
+export SAVEHIST=10000
+setopt HIST_IGNORE_DUPS
+setopt SHARE_HISTORY
+
+export ZSH="${HOME}/.oh-my-zsh"
+export EDITOR="nvim"
+
+ZSH_THEME=""
+
+HYPHEN_INSENSITIVE="true"
+COMPLETION_WAITING_DOTS="true"
+
+plugins=(git zsh-syntax-highlighting zsh-autosuggestions)
+
+source "${ZSH}/oh-my-zsh.sh"
+
+if (( $+commands[oh-my-posh] )); then
+  eval "$(oh-my-posh init zsh --config "${HOME}/.cache/oh-my-posh/themes/material.omp.json")"
+fi
+
+# source modular config files
+for config_file in aliases functions keybindings completions; do
+  [[ -f "${ZDOTDIR}/${config_file}.zsh" ]] && source "${ZDOTDIR}/${config_file}.zsh"
+done
+
+# blank line between prompts
+_print_blank_line() { print "" }
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _print_blank_line

--- a/mac/aliases.zsh
+++ b/mac/aliases.zsh
@@ -1,0 +1,11 @@
+alias g="git"
+alias vim="nvim"
+alias vi="nvim"
+
+alias cl="clear && ls"
+alias cs="clear && git status"
+alias sz='source "${ZDOTDIR}/.zshrc"'
+
+alias pth='echo $PATH | tr : "\n" | less'
+alias brew-up="brew update && brew upgrade"
+alias owd="open ."

--- a/mac/completions.zsh
+++ b/mac/completions.zsh
@@ -1,0 +1,14 @@
+# dotnet CLI completion
+_dotnet_zsh_complete() {
+  local completions=("$(dotnet complete --position $CURSOR "$BUFFER" 2>/dev/null)")
+  reply=(${(ps:\n:)completions})
+}
+if command -v dotnet &>/dev/null; then
+  compctl -K _dotnet_zsh_complete dotnet
+fi
+
+# GitHub Copilot CLI aliases
+if command -v gh &>/dev/null; then
+  _copilot_aliases="$(gh copilot alias -- zsh 2>/dev/null)" && eval "${_copilot_aliases}"
+  unset _copilot_aliases
+fi

--- a/mac/functions.zsh
+++ b/mac/functions.zsh
@@ -1,0 +1,59 @@
+find_dir() {
+  local search_path="${1:-.}"
+  local depth="${2:-0}"
+  find "${search_path}" -maxdepth $((depth + 1)) -type d \
+    -not -path '*/node_modules/*' \
+    -not -path '*/.*' \
+    -not -path '*/bin/*' \
+    -not -path '*/obj/*' 2>/dev/null | fzf
+}
+
+find_dir_and_go() {
+  local search_path="${1:-.}"
+  local depth="${2:-0}"
+  local choice
+  choice=$(find_dir "${search_path}" "${depth}")
+  [[ -n "${choice}" ]] && cd "${choice}"
+}
+
+alias fd="find_dir_and_go"
+
+fp() {
+  find_dir_and_go "${HOME}/projects" 0
+}
+
+fdx() {
+  find_dir_and_go "${HOME}/Exercism" 1
+}
+
+fdev() {
+  local search_path="${1:-${HOME}/projects}"
+  local depth="${2:-0}"
+  local session_name="${3:-}"
+
+  local choice
+  choice=$(find_dir "${search_path}" "${depth}")
+  [[ -z "${choice}" ]] && return
+
+  [[ -z "${session_name}" ]] && session_name=$(basename "${choice}")
+
+  osascript <<EOF
+tell application "iTerm2"
+  activate
+  tell current window
+    create tab with default profile
+    set newTab to current tab
+    tell current session of newTab
+      write text "cd '${choice}'"
+    end tell
+    set nvimSess to (split vertically with default profile of current session of newTab)
+    tell nvimSess
+      write text "cd '${choice}' && nvim"
+    end tell
+    tell current session of newTab
+      select
+    end tell
+  end tell
+end tell
+EOF
+}

--- a/mac/init.sh
+++ b/mac/init.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOTFILES_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MAC_DIR="${DOTFILES_DIR}/mac"
+
+echo "=== Mac + Oh My Zsh + Oh My Posh Bootstrap ==="
+echo "  Dotfiles: ${DOTFILES_DIR}"
+echo "  Mac dir:  ${MAC_DIR}"
+echo ""
+
+# ── Homebrew ───────────────────────────────────────────────────────
+if ! command -v brew &>/dev/null; then
+  echo "Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+else
+  echo "Homebrew already installed: $(brew --version | head -1)"
+fi
+
+# ── Homebrew packages ──────────────────────────────────────────────
+echo "Installing brew packages..."
+brew install \
+  zsh \
+  fzf \
+  ripgrep \
+  curl \
+  wget \
+  git \
+  gh \
+  neovim \
+  azure-cli \
+  terraform
+
+# ── FiraCode Nerd Font ─────────────────────────────────────────────
+if ! fc-list 2>/dev/null | grep -qi "firacode nerd"; then
+  echo "Installing FiraCode Nerd Font..."
+  brew install --cask font-fira-code-nerd-font
+else
+  echo "FiraCode Nerd Font already installed."
+fi
+
+# ── iTerm2 ─────────────────────────────────────────────────────────
+if ! brew list --cask iterm2 &>/dev/null; then
+  echo "Installing iTerm2..."
+  brew install --cask iterm2
+else
+  echo "iTerm2 already installed."
+fi
+
+# ── Neovim (via brew, already installed above) ─────────────────────
+echo "Neovim: $(nvim --version | head -1)"
+
+# ── .NET SDK (for csharp_ls / fsautocomplete LSP servers) ──────────
+export DOTNET_ROOT="${HOME}/.dotnet"
+export PATH="${DOTNET_ROOT}:${PATH}"
+
+if ! command -v dotnet &>/dev/null; then
+  echo "Installing .NET SDK (latest LTS)..."
+  curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel LTS --install-dir "${DOTNET_ROOT}"
+  echo ".NET SDK installed: $(dotnet --version)"
+else
+  echo ".NET SDK already installed: $(dotnet --version)"
+fi
+
+# ── nvm (Node Version Manager) ─────────────────────────────────────
+if [[ ! -d "${HOME}/.nvm" ]]; then
+  echo "Installing nvm..."
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | PROFILE=/dev/null bash
+  export NVM_DIR="${HOME}/.nvm"
+  [ -s "${NVM_DIR}/nvm.sh" ] && source "${NVM_DIR}/nvm.sh"
+  echo "Installing latest Node LTS..."
+  nvm install --lts
+else
+  echo "nvm already installed."
+  export NVM_DIR="${HOME}/.nvm"
+  [ -s "${NVM_DIR}/nvm.sh" ] && source "${NVM_DIR}/nvm.sh"
+  if ! command -v node &>/dev/null; then
+    echo "Node not found — installing latest LTS..."
+    nvm install --lts
+  fi
+fi
+
+# ── Oh My Zsh ─────────────────────────────────────────────────────
+if [[ ! -d "${HOME}/.oh-my-zsh" ]]; then
+  echo "Installing Oh My Zsh..."
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+else
+  echo "Oh My Zsh already installed."
+fi
+
+# ── Oh My Zsh plugins ─────────────────────────────────────────────
+ZSH_CUSTOM="${HOME}/.oh-my-zsh/custom"
+
+if [[ ! -d "${ZSH_CUSTOM}/plugins/zsh-syntax-highlighting" ]]; then
+  echo "Installing zsh-syntax-highlighting..."
+  git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "${ZSH_CUSTOM}/plugins/zsh-syntax-highlighting"
+fi
+
+if [[ ! -d "${ZSH_CUSTOM}/plugins/zsh-autosuggestions" ]]; then
+  echo "Installing zsh-autosuggestions..."
+  git clone https://github.com/zsh-users/zsh-autosuggestions.git "${ZSH_CUSTOM}/plugins/zsh-autosuggestions"
+fi
+
+# ── GitHub Copilot CLI ─────────────────────────────────────────────
+if ! command -v copilot &>/dev/null; then
+  echo "Installing GitHub Copilot CLI..."
+  npm install -g @github/copilot
+  echo "Copilot CLI installed: $(copilot --version)"
+else
+  echo "Copilot CLI already installed: $(copilot --version)"
+fi
+
+# ── Oh My Posh ─────────────────────────────────────────────────────
+if ! command -v oh-my-posh &>/dev/null; then
+  echo "Installing Oh My Posh..."
+  brew install jandedobbeleer/oh-my-posh/oh-my-posh
+else
+  echo "Oh My Posh already installed: $(oh-my-posh --version)"
+fi
+
+# Download themes if not present
+if [[ ! -f "${HOME}/.cache/oh-my-posh/themes/material.omp.json" ]]; then
+  echo "Downloading Oh My Posh themes..."
+  mkdir -p "${HOME}/.cache/oh-my-posh/themes"
+  oh-my-posh get themes --path "${HOME}/.cache/oh-my-posh/themes" 2>/dev/null || true
+fi
+
+# ── ZDOTDIR setup (~/.zshenv) ──────────────────────────────────────
+echo "Setting up ZDOTDIR in ~/.zshenv..."
+if [[ -f "${HOME}/.zshenv" ]]; then
+  echo "  Backing up existing ~/.zshenv to ~/.zshenv.bak"
+  cp "${HOME}/.zshenv" "${HOME}/.zshenv.bak"
+fi
+echo "export ZDOTDIR=\"${MAC_DIR}\"" > "${HOME}/.zshenv"
+
+# ── Git config symlink ─────────────────────────────────────────────
+GITCONFIG_TARGET="${MAC_DIR}/.gitconfig"
+if [[ -L "${HOME}/.gitconfig" && "$(readlink "${HOME}/.gitconfig")" == "${GITCONFIG_TARGET}" ]]; then
+  echo "Git config symlink already correct."
+else
+  echo "Symlinking Git config..."
+  if [[ -L "${HOME}/.gitconfig" ]]; then
+    rm "${HOME}/.gitconfig"
+  elif [[ -e "${HOME}/.gitconfig" ]]; then
+    echo "  Backing up existing ~/.gitconfig to ~/.gitconfig.bak"
+    mv "${HOME}/.gitconfig" "${HOME}/.gitconfig.bak"
+  fi
+  ln -s "${GITCONFIG_TARGET}" "${HOME}/.gitconfig"
+fi
+
+# ── Neovim config symlink ─────────────────────────────────────────
+echo "Symlinking Neovim config..."
+mkdir -p "${HOME}/.config"
+if [[ -L "${HOME}/.config/nvim" ]]; then
+  rm "${HOME}/.config/nvim"
+elif [[ -d "${HOME}/.config/nvim" ]]; then
+  echo "  Backing up existing nvim config to ~/.config/nvim.bak"
+  mv "${HOME}/.config/nvim" "${HOME}/.config/nvim.bak"
+fi
+ln -s "${DOTFILES_DIR}/nvim" "${HOME}/.config/nvim"
+
+# ── iTerm2 profile import ─────────────────────────────────────────
+echo ""
+echo "iTerm2 setup:"
+echo "  1. Open iTerm2 → Preferences → Profiles → Other Actions → Import JSON Profiles"
+echo "     Import: ${MAC_DIR}/iterm2/Default.json"
+echo "  2. Open iTerm2 → Preferences → Profiles → Colors → Color Presets → Import"
+echo "     Import: ${MAC_DIR}/iterm2/GitHub Dark.itermcolors"
+echo "  3. Set the imported profile as default."
+
+# ── Set ZSH as default shell ──────────────────────────────────────
+ZSH_PATH="$(brew --prefix)/bin/zsh"
+if [[ "$(basename "$SHELL")" != "zsh" ]] || [[ "$SHELL" != "${ZSH_PATH}" ]]; then
+  echo "Setting Homebrew ZSH as default shell..."
+  if ! grep -qF "${ZSH_PATH}" /etc/shells; then
+    echo "${ZSH_PATH}" | sudo tee -a /etc/shells
+  fi
+  chsh -s "${ZSH_PATH}" || echo "  chsh failed — run manually: chsh -s ${ZSH_PATH}"
+else
+  echo "ZSH is already the default shell."
+fi
+
+echo ""
+echo "=== Setup complete! ==="
+echo ""
+echo "What was set up:"
+echo "  ~/.zshenv          → points ZDOTDIR to ${MAC_DIR}"
+echo "  ~/.gitconfig       → symlinked to ${MAC_DIR}/.gitconfig"
+echo "  ~/.config/nvim     → symlinked to ${DOTFILES_DIR}/nvim"
+echo "  oh-my-zsh          → ${HOME}/.oh-my-zsh"
+echo "  oh-my-posh         → $(command -v oh-my-posh 2>/dev/null || echo 'not found')"
+echo "  gh                 → $(command -v gh 2>/dev/null || echo 'not found')"
+echo "  az                 → $(command -v az 2>/dev/null || echo 'not found')"
+echo "  terraform          → $(command -v terraform 2>/dev/null || echo 'not found')"
+echo "  copilot            → $(command -v copilot 2>/dev/null || echo 'not found')"
+echo "  nvm                → ${HOME}/.nvm"
+echo "  dotnet             → $(command -v dotnet 2>/dev/null || echo 'not found')"
+echo ""
+echo "Restart your terminal or run: exec zsh"

--- a/mac/init.sh
+++ b/mac/init.sh
@@ -34,7 +34,7 @@ brew install \
   terraform
 
 # ── FiraCode Nerd Font ─────────────────────────────────────────────
-if ! fc-list 2>/dev/null | grep -qi "firacode nerd"; then
+if ! brew list --cask font-fira-code-nerd-font &>/dev/null; then
   echo "Installing FiraCode Nerd Font..."
   brew install --cask font-fira-code-nerd-font
 else

--- a/mac/init.sh
+++ b/mac/init.sh
@@ -34,12 +34,8 @@ brew install \
   terraform
 
 # ── FiraCode Nerd Font ─────────────────────────────────────────────
-if ! brew list --cask font-fira-code-nerd-font &>/dev/null; then
-  echo "Installing FiraCode Nerd Font..."
-  brew install --cask font-fira-code-nerd-font
-else
-  echo "FiraCode Nerd Font already installed."
-fi
+echo "Installing FiraCode Nerd Font (skipping if already installed)..."
+brew install --cask font-fira-code-nerd-font || true
 
 # ── iTerm2 ─────────────────────────────────────────────────────────
 if ! brew list --cask iterm2 &>/dev/null; then

--- a/mac/iterm2/Default.json
+++ b/mac/iterm2/Default.json
@@ -1,0 +1,336 @@
+{
+  "Profiles": [
+    {
+      "Name": "Default",
+      "Guid": "00000000-0000-0000-0000-000000000001",
+      "Custom Command": "No",
+      "Working Directory": "~",
+
+      "Normal Font": "FiraCodeNFM-Reg 13",
+      "Non Ascii Font": "FiraCodeNFM-Reg 13",
+      "Use Non-ASCII Font": false,
+      "Horizontal Spacing": 1,
+      "Vertical Spacing": 1,
+
+      "Default Bookmark": "Yes",
+
+      "Initial Use Transparency": false,
+      "Transparency": 0,
+
+      "Scrollback Lines": 10000,
+      "Scrollback With Status Bar": false,
+      "Hide Scrollbar": true,
+
+      "Terminal Type": "xterm-256color",
+      "Unicode Normalization": 0,
+      "Option Key Sends": 2,
+      "Right Option Key Sends": 2,
+
+      "Columns": 120,
+      "Rows": 40,
+
+      "Custom Window Title": "",
+      "Use Custom Window Title": false,
+
+      "Copy to Pasteboard on Selection": false,
+
+      "Draw Powerline Glyphs": true,
+      "Use Ligatures": true,
+
+      "Background Color": {
+        "Red Component": 0.050980392156862744,
+        "Green Component": 0.06666666666666667,
+        "Blue Component": 0.09019607843137255,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Foreground Color": {
+        "Red Component": 0.788235294117647,
+        "Green Component": 0.8196078431372549,
+        "Blue Component": 0.8509803921568627,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Bold Color": {
+        "Red Component": 0.788235294117647,
+        "Green Component": 0.8196078431372549,
+        "Blue Component": 0.8509803921568627,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Cursor Color": {
+        "Red Component": 0.788235294117647,
+        "Green Component": 0.8196078431372549,
+        "Blue Component": 0.8509803921568627,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Cursor Text Color": {
+        "Red Component": 0.050980392156862744,
+        "Green Component": 0.06666666666666667,
+        "Blue Component": 0.09019607843137255,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Selection Color": {
+        "Red Component": 0.12941176470588237,
+        "Green Component": 0.14901960784313725,
+        "Blue Component": 0.17647058823529413,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Selected Text Color": {
+        "Red Component": 0.788235294117647,
+        "Green Component": 0.8196078431372549,
+        "Blue Component": 0.8509803921568627,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 0 Color": {
+        "Red Component": 0.2823529411764706,
+        "Green Component": 0.30980392156862746,
+        "Blue Component": 0.34509803921568627,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 1 Color": {
+        "Red Component": 1.0,
+        "Green Component": 0.4823529411764706,
+        "Blue Component": 0.44705882352941173,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 2 Color": {
+        "Red Component": 0.24705882352941178,
+        "Green Component": 0.7254901960784313,
+        "Blue Component": 0.31372549019607843,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 3 Color": {
+        "Red Component": 0.8235294117647058,
+        "Green Component": 0.6,
+        "Blue Component": 0.13333333333333333,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 4 Color": {
+        "Red Component": 0.34509803921568627,
+        "Green Component": 0.6509803921568628,
+        "Blue Component": 1.0,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 5 Color": {
+        "Red Component": 0.7372549019607844,
+        "Green Component": 0.5490196078431373,
+        "Blue Component": 1.0,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 6 Color": {
+        "Red Component": 0.2235294117647059,
+        "Green Component": 0.7725490196078432,
+        "Blue Component": 0.8117647058823529,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 7 Color": {
+        "Red Component": 0.6941176470588235,
+        "Green Component": 0.7294117647058823,
+        "Blue Component": 0.7058823529411765,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 8 Color": {
+        "Red Component": 0.43137254901960786,
+        "Green Component": 0.4627450980392157,
+        "Blue Component": 0.5058823529411764,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 9 Color": {
+        "Red Component": 1.0,
+        "Green Component": 0.4823529411764706,
+        "Blue Component": 0.44705882352941173,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 10 Color": {
+        "Red Component": 0.33725490196078434,
+        "Green Component": 0.8274509803921568,
+        "Blue Component": 0.39215686274509803,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 11 Color": {
+        "Red Component": 0.8901960784313725,
+        "Green Component": 0.7019607843137254,
+        "Blue Component": 0.2549019607843137,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 12 Color": {
+        "Red Component": 0.47450980392156863,
+        "Green Component": 0.7529411764705882,
+        "Blue Component": 1.0,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 13 Color": {
+        "Red Component": 0.8235294117647058,
+        "Green Component": 0.6784313725490196,
+        "Blue Component": 1.0,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 14 Color": {
+        "Red Component": 0.33725490196078434,
+        "Green Component": 0.8352941176470589,
+        "Blue Component": 0.8666666666666667,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+      "Ansi 15 Color": {
+        "Red Component": 1.0,
+        "Green Component": 1.0,
+        "Blue Component": 1.0,
+        "Alpha Component": 1,
+        "Color Space": "sRGB"
+      },
+
+      "Keyboard Map": {
+        "0x0d-0x20000": {
+          "Action": 12,
+          "Text": "\u001b\r",
+          "Label": "Send ESC+Enter"
+        },
+        "0xf702-0x40000": {
+          "Action": 10,
+          "Text": "[1;5D",
+          "Label": "Move Focus Left (ctrl+left → ctrl+home equiv)"
+        },
+        "0xf700-0x40000": {
+          "Action": 10,
+          "Text": "[1;5A",
+          "Label": "Move Focus Up (ctrl+up)"
+        },
+        "0xf703-0x40000": {
+          "Action": 10,
+          "Text": "[1;5C",
+          "Label": "Move Focus Right (ctrl+right)"
+        },
+        "0xf701-0x40000": {
+          "Action": 10,
+          "Text": "[1;5B",
+          "Label": "Move Focus Down (ctrl+down)"
+        },
+        "0xf72c-0x40000": {
+          "Action": 10,
+          "Text": "[5;5~",
+          "Label": "Move Focus Up (ctrl+pgup)"
+        },
+        "0xf72d-0x40000": {
+          "Action": 10,
+          "Text": "[6;5~",
+          "Label": "Move Focus Down (ctrl+pgdn)"
+        },
+        "0xf729-0x40000": {
+          "Action": 10,
+          "Text": "[1;5H",
+          "Label": "Move Focus Left (ctrl+home)"
+        },
+        "0xf72b-0x40000": {
+          "Action": 10,
+          "Text": "[1;5F",
+          "Label": "Move Focus Right (ctrl+end)"
+        },
+        "0xf729-0x60000": {
+          "Action": 27,
+          "Text": "",
+          "Label": "Split Pane Left (ctrl+shift+home)"
+        },
+        "0xf72b-0x60000": {
+          "Action": 26,
+          "Text": "",
+          "Label": "Split Pane Right (ctrl+shift+end)"
+        },
+        "0xf72c-0x60000": {
+          "Action": 25,
+          "Text": "",
+          "Label": "Split Pane Up (ctrl+shift+pgup)"
+        },
+        "0xf72d-0x60000": {
+          "Action": 24,
+          "Text": "",
+          "Label": "Split Pane Down (ctrl+shift+pgdn)"
+        },
+        "0xf729-0x80000": {
+          "Action": 32,
+          "Text": "",
+          "Label": "Previous Tab (alt+home)"
+        },
+        "0xf72b-0x80000": {
+          "Action": 33,
+          "Text": "",
+          "Label": "Next Tab (alt+end)"
+        },
+        "0xf72c-0xa0000": {
+          "Action": 7,
+          "Text": "",
+          "Label": "Scroll Up Page (alt+shift+pgup)"
+        },
+        "0xf72d-0xa0000": {
+          "Action": 6,
+          "Text": "",
+          "Label": "Scroll Down Page (alt+shift+pgdn)"
+        },
+        "0xf729-0xa0000": {
+          "Action": 5,
+          "Text": "",
+          "Label": "Scroll To Top (alt+shift+home)"
+        },
+        "0xf72b-0xa0000": {
+          "Action": 4,
+          "Text": "",
+          "Label": "Scroll To Bottom (alt+shift+end)"
+        },
+        "0xf729-0x20000": {
+          "Action": 7,
+          "Text": "",
+          "Label": "Resize Pane Left (shift+home)"
+        },
+        "0xf72b-0x20000": {
+          "Action": 6,
+          "Text": "",
+          "Label": "Resize Pane Right (shift+end)"
+        },
+        "0xf72c-0x20000": {
+          "Action": 5,
+          "Text": "",
+          "Label": "Resize Pane Up (shift+pgup)"
+        },
+        "0xf72d-0x20000": {
+          "Action": 4,
+          "Text": "",
+          "Label": "Resize Pane Down (shift+pgdn)"
+        },
+        "0x66-0x60000": {
+          "Action": 17,
+          "Text": "",
+          "Label": "Find (ctrl+shift+f)"
+        },
+        "0x77-0x60000": {
+          "Action": 28,
+          "Text": "",
+          "Label": "Close Pane (ctrl+shift+w)"
+        },
+        "0x74-0x60000": {
+          "Action": 29,
+          "Text": "",
+          "Label": "New Tab (ctrl+shift+t)"
+        }
+      }
+    }
+  ]
+}

--- a/mac/iterm2/GitHub Dark.itermcolors
+++ b/mac/iterm2/GitHub Dark.itermcolors
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!-- GitHub Dark color scheme — converted from Windows Terminal settings.json -->
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.34509803921568627</real>
+		<key>Green Component</key>
+		<real>0.30980392156862746</real>
+		<key>Red Component</key>
+		<real>0.2823529411764706</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.44705882352941173</real>
+		<key>Green Component</key>
+		<real>0.4823529411764706</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.31372549019607843</real>
+		<key>Green Component</key>
+		<real>0.7254901960784313</real>
+		<key>Red Component</key>
+		<real>0.24705882352941178</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.13333333333333333</real>
+		<key>Green Component</key>
+		<real>0.6</real>
+		<key>Red Component</key>
+		<real>0.8235294117647058</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Green Component</key>
+		<real>0.6509803921568628</real>
+		<key>Red Component</key>
+		<real>0.34509803921568627</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Green Component</key>
+		<real>0.5490196078431373</real>
+		<key>Red Component</key>
+		<real>0.7372549019607844</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8117647058823529</real>
+		<key>Green Component</key>
+		<real>0.7725490196078432</real>
+		<key>Red Component</key>
+		<real>0.2235294117647059</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.7058823529411765</real>
+		<key>Green Component</key>
+		<real>0.7294117647058823</real>
+		<key>Red Component</key>
+		<real>0.6941176470588235</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.5058823529411764</real>
+		<key>Green Component</key>
+		<real>0.4627450980392157</real>
+		<key>Red Component</key>
+		<real>0.43137254901960786</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.44705882352941173</real>
+		<key>Green Component</key>
+		<real>0.4823529411764706</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.39215686274509803</real>
+		<key>Green Component</key>
+		<real>0.8274509803921568</real>
+		<key>Red Component</key>
+		<real>0.33725490196078434</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.2549019607843137</real>
+		<key>Green Component</key>
+		<real>0.7019607843137254</real>
+		<key>Red Component</key>
+		<real>0.8901960784313725</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Green Component</key>
+		<real>0.7529411764705882</real>
+		<key>Red Component</key>
+		<real>0.47450980392156863</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Green Component</key>
+		<real>0.6784313725490196</real>
+		<key>Red Component</key>
+		<real>0.8235294117647058</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8666666666666667</real>
+		<key>Green Component</key>
+		<real>0.8352941176470589</real>
+		<key>Red Component</key>
+		<real>0.33725490196078434</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.09019607843137255</real>
+		<key>Green Component</key>
+		<real>0.06666666666666667</real>
+		<key>Red Component</key>
+		<real>0.050980392156862744</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8509803921568627</real>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.788235294117647</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8509803921568627</real>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.788235294117647</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.09019607843137255</real>
+		<key>Green Component</key>
+		<real>0.06666666666666667</real>
+		<key>Red Component</key>
+		<real>0.050980392156862744</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8509803921568627</real>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.788235294117647</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Green Component</key>
+		<real>0.6509803921568628</real>
+		<key>Red Component</key>
+		<real>0.34509803921568627</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.8509803921568627</real>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.788235294117647</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Blue Component</key>
+		<real>0.17647058823529413</real>
+		<key>Green Component</key>
+		<real>0.14901960784313725</real>
+		<key>Red Component</key>
+		<real>0.12941176470588237</real>
+	</dict>
+</dict>
+</plist>

--- a/mac/keybindings.zsh
+++ b/mac/keybindings.zsh
@@ -1,0 +1,15 @@
+bindkey -v
+
+# reduce mode switch delay
+export KEYTIMEOUT=1
+
+# history search with up/down in vi mode
+bindkey '^[[A' history-beginning-search-backward
+bindkey '^[[B' history-beginning-search-forward
+bindkey -a 'k' history-beginning-search-backward
+bindkey -a 'j' history-beginning-search-forward
+
+# autosuggestion navigation (mirrors PSReadLine Ctrl+n/p/y)
+bindkey '^n' autosuggest-fetch
+bindkey '^p' up-line-or-history
+bindkey '^y' autosuggest-accept


### PR DESCRIPTION
## Summary

Adds a `mac/` directory with a full macOS dev environment setup, mirroring the existing `zsh/` (WSL) and `powershell/` configs.

## ZSH Config (`mac/`)

- `.zshrc` — same structure as `zsh/`, adds Homebrew PATH (`/opt/homebrew/bin`)
- `aliases.zsh` — `brew-up` instead of `sau`, `owd=open .`, no WSL wrappers
- `functions.zsh` — `fdev` uses iTerm2 AppleScript to open new tab + vertical split with nvim
- `keybindings.zsh`, `completions.zsh` — identical to `zsh/`
- `.gitconfig` — same aliases, `osxkeychain` credential helper
- `init.sh` — Homebrew bootstrap (packages, Oh My Zsh, Oh My Posh, .NET, nvm, FiraCode Nerd Font, iTerm2 cask, symlinks)

## iTerm2 Config (`mac/iterm2/`)

Mirrors `wt/settings.json` for macOS:

- `GitHub Dark.itermcolors` — color scheme converted from WT `schemes[]`
- `Default.json` — importable iTerm2 profile with:
  - FiraCode Nerd Font 13pt
  - GitHub Dark colors (inline, no import dependency)
  - 120×40 window, scrollbar hidden
  - Full key binding translation from Windows Terminal (shift+enter→ESC+Enter, pane focus, pane split, tab nav, scrolling)

## Deployment

Run `mac/init.sh`, then import `mac/iterm2/Default.json` in iTerm2 Preferences.