### PR TITLE
feat: add post-push PR verification workflow and script

### DIFF
--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -27,10 +27,10 @@ Use **trunk-based development** against `master`. Never commit directly to `mast
 
 After every push to a PR branch, verify the PR is healthy before considering the work done:
 
-1. **Run the verification script.** Use `scripts/wait-for-pr-reviews.sh <PR_NUMBER>` to wait for CI checks and Copilot code review, then check for unresolved review threads. The script:
-   - Waits for all CI check runs to complete via `gh pr checks --watch`.
-   - Polls for the "Copilot code review" workflow run matching the PR's head SHA, then watches it until completion (default timeout: 5 minutes, configurable with `--timeout`). CI checks also have a timeout (default: 10 minutes, configurable with `--ci-timeout`).
-   - Queries unresolved review threads via GraphQL (up to 100 threads per PR) and reports them.
+1. **Run the verification script.** Use `scripts/wait-for-pr-reviews.sh <PR_NUMBER>` to wait for CI checks and Copilot code review, then check for unresolved review threads. The script must be run from within the cloned repo. It:
+   - Waits for all CI check runs to complete via `gh pr checks --watch`. Skips gracefully if no CI checks are configured.
+   - Polls for the "Copilot code review" workflow run matching the PR's head SHA, then watches it until completion (default timeout: 5 minutes, configurable with `--timeout`). Skips gracefully if no such workflow exists. CI checks also have a timeout (default: 10 minutes, configurable with `--ci-timeout`).
+   - Queries unresolved review threads via GraphQL (up to 100 threads per PR) and reports them — this catches Copilot review comments regardless of whether the workflow was found.
    - Exits 0 if clean, 1 if unresolved threads exist, 2 if CI failed, 3 if the thread query failed.
 2. **Address all review feedback.** For each unresolved review thread: fix the issue, commit, push, and reply to the comment thread explaining what changed and referencing the commit SHA.
    - **Copilot review threads:** After replying, resolve the thread using the GraphQL `resolveReviewThread` mutation so it collapses in the PR timeline.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -1,5 +1,11 @@
 # Agent Instructions
 
+## Collaboration expectations
+
+- Keep commits small and focused on a single coherent change.
+- Use conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`, etc.
+- Favor small, composable changes that are easy to review.
+
 ## Git Workflow
 
 Use **trunk-based development** against `master`. Never commit directly to `master`.
@@ -7,15 +13,31 @@ Use **trunk-based development** against `master`. Never commit directly to `mast
 - Create **feature branches** for each logical unit of work (e.g., `feat/zsh-core`, `fix/nvim-lsp`)
 - Push the branch and **raise a PR** for review
 - When work spans multiple PRs, **stack branches** (each based on the previous) and note dependencies in PR descriptions
-- Always respond to PR review comments — reply to each thread explaining what was fixed or why feedback was declined
-- Use conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`, etc.
+- Branch naming: `feat/<feature>`, `fix/<issue>`, `docs/<topic>`, `chore/<task>`
+- **Do not rebase or force-push when addressing PR feedback.** Make separate commits for each fix so the review history is visible. PRs are squash-merged, so feature branch commit history does not need to be clean.
 
 ## PR Operations
 
 - Before pushing, merge `master` into the feature branch to keep it up to date
-- After addressing review feedback, commit and push the fixes, then reply to each comment thread
-- After every push to a PR, poll for new review feedback and address it iteratively until there are no unresolved comments
-- When creating PRs, include a summary table of changes and note any dependencies on other PRs
+- When creating PRs, include a summary of changes and note any dependencies on other PRs
+- **Use file-based input for PR bodies.** Write the body to a temporary file and pass it via `gh pr create --body-file` or `gh api -F body=@file`. Do not pass markdown inline — shells mangle backticks and special characters.
+- The user reviews every PR before merge. Do not merge PRs without explicit user approval.
+
+## Post-push PR verification
+
+After every push to a PR branch, verify the PR is healthy before considering the work done:
+
+1. **Run the verification script.** Use `scripts/wait-for-pr-reviews.sh <PR_NUMBER>` to wait for CI checks and Copilot code review, then check for unresolved review threads. The script:
+   - Waits for all CI check runs to complete via `gh pr checks --watch`.
+   - Polls for the "Copilot code review" workflow run matching the PR's head SHA, then watches it until completion (default timeout: 5 minutes, configurable with `--timeout`). CI checks also have a timeout (default: 10 minutes, configurable with `--ci-timeout`).
+   - Queries unresolved review threads via GraphQL (up to 100 threads per PR) and reports them.
+   - Exits 0 if clean, 1 if unresolved threads exist, 2 if CI failed, 3 if the thread query failed.
+2. **Address all review feedback.** For each unresolved review thread: fix the issue, commit, push, and reply to the comment thread explaining what changed and referencing the commit SHA.
+   - **Copilot review threads:** After replying, resolve the thread using the GraphQL `resolveReviewThread` mutation so it collapses in the PR timeline.
+   - **Human review threads:** Reply with the fix explanation but **do not resolve** the thread. The reviewer will resolve it after confirming the fix.
+3. **Iterate until clean.** Each fix-and-push cycle triggers new CI runs and may trigger new reviews. Repeat steps 1–2 until all checks pass, all Copilot review threads are resolved, and all human review threads have been replied to.
+
+This applies to every push — initial PR creation, feedback fixes, and follow-up commits alike.
 
 ## Bootstrap Scripts
 

--- a/scripts/wait-for-pr-reviews.sh
+++ b/scripts/wait-for-pr-reviews.sh
@@ -103,12 +103,13 @@ echo ""
 
 echo "--- Step 1: Waiting for CI checks (timeout: ${CI_TIMEOUT}s) ---"
 set +e
+CI_OUTPUT=""
 if command -v timeout &>/dev/null; then
-    timeout "$CI_TIMEOUT" gh pr checks "$PR_NUMBER" --watch 2>&1
+    CI_OUTPUT=$(timeout "$CI_TIMEOUT" gh pr checks "$PR_NUMBER" --watch 2>&1)
     CI_EXIT=$?
 else
     echo "⚠️  'timeout' command not found; CI wait has no timeout." >&2
-    gh pr checks "$PR_NUMBER" --watch 2>&1
+    CI_OUTPUT=$(gh pr checks "$PR_NUMBER" --watch 2>&1)
     CI_EXIT=$?
 fi
 set -e
@@ -117,13 +118,18 @@ if [[ $CI_EXIT -eq 124 ]]; then
     echo ""
     echo "❌ CI checks did not complete within ${CI_TIMEOUT}s."
     exit 2
+elif [[ $CI_EXIT -ne 0 ]] && echo "$CI_OUTPUT" | grep -qi "no checks"; then
+    echo "ℹ️  No CI checks configured for this PR. Skipping."
 elif [[ $CI_EXIT -ne 0 ]]; then
+    echo "$CI_OUTPUT"
     echo ""
     echo "❌ One or more CI checks failed."
     exit 2
+else
+    echo "$CI_OUTPUT"
+    echo ""
+    echo "✅ CI checks passed."
 fi
-echo ""
-echo "✅ CI checks passed."
 echo ""
 
 # ── Step 2: Wait for Copilot code review ────────────────────────────

--- a/scripts/wait-for-pr-reviews.sh
+++ b/scripts/wait-for-pr-reviews.sh
@@ -86,7 +86,11 @@ fi
 
 # ── Detect repository and validate PR ───────────────────────────────
 
-REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+if ! REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
+    echo "Error: not inside a GitHub repository. Run this script from within a cloned repo." >&2
+    [[ -n "$REPO_NWO" ]] && echo "$REPO_NWO" >&2
+    exit 1
+fi
 OWNER="${REPO_NWO%%/*}"
 REPO="${REPO_NWO##*/}"
 
@@ -137,48 +141,59 @@ echo ""
 echo "--- Step 2: Waiting for Copilot code review (timeout: ${COPILOT_TIMEOUT}s) ---"
 echo "PR head SHA: ${HEAD_SHA:0:12}"
 
-ELAPSED=0
-COPILOT_DONE=false
+# Check if the Copilot review workflow exists before polling.
+set +e
+WORKFLOW_CHECK=$(gh run list -w "$COPILOT_REVIEW_WORKFLOW" -L 1 --json databaseId 2>&1)
+WORKFLOW_EXIT=$?
+set -e
 
-while [[ $ELAPSED -lt $COPILOT_TIMEOUT ]]; do
-    MATCH=$(gh run list \
-        -w "$COPILOT_REVIEW_WORKFLOW" \
-        --json databaseId,headSha,status,conclusion \
-        -L 50 \
-        --jq '.[] | select(.headSha == "'"$HEAD_SHA"'") | "\(.databaseId)\t\(.status)\t\(.conclusion // "pending")"' \
-        2>&1 | head -1 || true)
-
-    if [[ -n "$MATCH" && ! "$MATCH" == *$'\t'* ]]; then
-        echo "⚠️  gh run list: $MATCH" >&2
-        MATCH=""
-    fi
-
-    if [[ -n "$MATCH" ]]; then
-        IFS=$'\t' read -r RUN_ID STATUS CONCLUSION <<< "$MATCH"
-
-        if [[ "$STATUS" == "completed" ]]; then
-            if [[ "$CONCLUSION" == "success" ]]; then
-                echo "✅ Copilot code review completed (run ${RUN_ID})."
-            else
-                echo "⚠️  Copilot code review completed with conclusion: ${CONCLUSION} (run ${RUN_ID})."
-            fi
-            COPILOT_DONE=true
-            break
-        fi
-        echo "⏳ Copilot code review in progress (run ${RUN_ID}, status: ${STATUS})... [${ELAPSED}s/${COPILOT_TIMEOUT}s]"
-    else
-        echo "⏳ Waiting for Copilot code review to start... [${ELAPSED}s/${COPILOT_TIMEOUT}s]"
-    fi
-
-    sleep "$POLL_INTERVAL"
-    ELAPSED=$((ELAPSED + POLL_INTERVAL))
-done
-
-if [[ "$COPILOT_DONE" != "true" ]]; then
-    echo "⚠️  Copilot review did not complete within ${COPILOT_TIMEOUT}s. Checking threads anyway."
+if [[ $WORKFLOW_EXIT -ne 0 ]] || echo "$WORKFLOW_CHECK" | grep -qi "could not find\|no workflow\|not found"; then
+    echo "ℹ️  No '${COPILOT_REVIEW_WORKFLOW}' workflow found. Skipping."
+    echo "   Copilot review threads (if any) will still be checked in Step 3."
 else
-    echo "Waiting ${THREAD_PROPAGATION_DELAY}s for review threads to propagate..."
-    sleep "$THREAD_PROPAGATION_DELAY"
+    ELAPSED=0
+    COPILOT_DONE=false
+
+    while [[ $ELAPSED -lt $COPILOT_TIMEOUT ]]; do
+        MATCH=$(gh run list \
+            -w "$COPILOT_REVIEW_WORKFLOW" \
+            --json databaseId,headSha,status,conclusion \
+            -L 50 \
+            --jq '.[] | select(.headSha == "'"$HEAD_SHA"'") | "\(.databaseId)\t\(.status)\t\(.conclusion // "pending")"' \
+            2>&1 | head -1 || true)
+
+        if [[ -n "$MATCH" && ! "$MATCH" == *$'\t'* ]]; then
+            echo "⚠️  gh run list: $MATCH" >&2
+            MATCH=""
+        fi
+
+        if [[ -n "$MATCH" ]]; then
+            IFS=$'\t' read -r RUN_ID STATUS CONCLUSION <<< "$MATCH"
+
+            if [[ "$STATUS" == "completed" ]]; then
+                if [[ "$CONCLUSION" == "success" ]]; then
+                    echo "✅ Copilot code review completed (run ${RUN_ID})."
+                else
+                    echo "⚠️  Copilot code review completed with conclusion: ${CONCLUSION} (run ${RUN_ID})."
+                fi
+                COPILOT_DONE=true
+                break
+            fi
+            echo "⏳ Copilot code review in progress (run ${RUN_ID}, status: ${STATUS})... [${ELAPSED}s/${COPILOT_TIMEOUT}s]"
+        else
+            echo "⏳ Waiting for Copilot code review to start... [${ELAPSED}s/${COPILOT_TIMEOUT}s]"
+        fi
+
+        sleep "$POLL_INTERVAL"
+        ELAPSED=$((ELAPSED + POLL_INTERVAL))
+    done
+
+    if [[ "$COPILOT_DONE" != "true" ]]; then
+        echo "⚠️  Copilot review did not complete within ${COPILOT_TIMEOUT}s. Checking threads anyway."
+    else
+        echo "Waiting ${THREAD_PROPAGATION_DELAY}s for review threads to propagate..."
+        sleep "$THREAD_PROPAGATION_DELAY"
+    fi
 fi
 echo ""
 

--- a/scripts/wait-for-pr-reviews.sh
+++ b/scripts/wait-for-pr-reviews.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post-push PR verification script.
+#
+# Waits for CI checks and Copilot code review to complete, then reports
+# unresolved review threads on the PR (up to 100 threads inspected).
+#
+# Requires: gh CLI (authenticated)
+
+export GH_PAGER=cat
+
+COPILOT_REVIEW_WORKFLOW="Copilot code review"
+DEFAULT_COPILOT_TIMEOUT=300
+DEFAULT_CI_TIMEOUT=600
+POLL_INTERVAL=15
+THREAD_PROPAGATION_DELAY=15
+
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+Usage: $SCRIPT_NAME <PR_NUMBER> [options]
+
+Waits for CI checks and Copilot code review, then reports unresolved threads.
+
+Options:
+  --timeout <seconds>     Max time to wait for Copilot review (default: $DEFAULT_COPILOT_TIMEOUT)
+  --ci-timeout <seconds>  Max time to wait for CI checks (default: $DEFAULT_CI_TIMEOUT)
+  -h, --help              Show this help
+
+Exit codes:
+  0  All clear — checks passed, no unresolved review threads
+  1  Unresolved review threads found (details printed to stdout)
+  2  CI checks failed or timed out
+  3  Failed to query review threads (API/auth error)
+EOF
+}
+
+# ── Argument parsing ────────────────────────────────────────────────
+
+PR_NUMBER=""
+COPILOT_TIMEOUT="$DEFAULT_COPILOT_TIMEOUT"
+CI_TIMEOUT="$DEFAULT_CI_TIMEOUT"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --timeout)
+            [[ $# -ge 2 ]] || { echo "Error: --timeout requires a value" >&2; exit 1; }
+            COPILOT_TIMEOUT="$2"
+            [[ "$COPILOT_TIMEOUT" =~ ^[0-9]+$ ]] || { echo "Error: --timeout must be a number" >&2; exit 1; }
+            shift 2
+            ;;
+        --ci-timeout)
+            [[ $# -ge 2 ]] || { echo "Error: --ci-timeout requires a value" >&2; exit 1; }
+            CI_TIMEOUT="$2"
+            [[ "$CI_TIMEOUT" =~ ^[0-9]+$ ]] || { echo "Error: --ci-timeout must be a number" >&2; exit 1; }
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            if [[ -z "$PR_NUMBER" ]]; then
+                PR_NUMBER="$1"
+            else
+                echo "Error: unexpected argument: $1" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$PR_NUMBER" ]]; then
+    echo "Error: PR number is required." >&2
+    usage >&2
+    exit 1
+fi
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR number must be a positive integer, got: $PR_NUMBER" >&2
+    exit 1
+fi
+
+# ── Detect repository and validate PR ───────────────────────────────
+
+REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+OWNER="${REPO_NWO%%/*}"
+REPO="${REPO_NWO##*/}"
+
+if ! HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid 2>&1); then
+    echo "Error: could not find PR #${PR_NUMBER} in ${REPO_NWO}" >&2
+    echo "$HEAD_SHA" >&2
+    exit 1
+fi
+
+echo "=== Post-push PR verification: ${REPO_NWO}#${PR_NUMBER} ==="
+echo ""
+
+# ── Step 1: Wait for CI checks ──────────────────────────────────────
+
+echo "--- Step 1: Waiting for CI checks (timeout: ${CI_TIMEOUT}s) ---"
+set +e
+if command -v timeout &>/dev/null; then
+    timeout "$CI_TIMEOUT" gh pr checks "$PR_NUMBER" --watch 2>&1
+    CI_EXIT=$?
+else
+    echo "⚠️  'timeout' command not found; CI wait has no timeout." >&2
+    gh pr checks "$PR_NUMBER" --watch 2>&1
+    CI_EXIT=$?
+fi
+set -e
+
+if [[ $CI_EXIT -eq 124 ]]; then
+    echo ""
+    echo "❌ CI checks did not complete within ${CI_TIMEOUT}s."
+    exit 2
+elif [[ $CI_EXIT -ne 0 ]]; then
+    echo ""
+    echo "❌ One or more CI checks failed."
+    exit 2
+fi
+echo ""
+echo "✅ CI checks passed."
+echo ""
+
+# ── Step 2: Wait for Copilot code review ────────────────────────────
+
+echo "--- Step 2: Waiting for Copilot code review (timeout: ${COPILOT_TIMEOUT}s) ---"
+echo "PR head SHA: ${HEAD_SHA:0:12}"
+
+ELAPSED=0
+COPILOT_DONE=false
+
+while [[ $ELAPSED -lt $COPILOT_TIMEOUT ]]; do
+    MATCH=$(gh run list \
+        -w "$COPILOT_REVIEW_WORKFLOW" \
+        --json databaseId,headSha,status,conclusion \
+        -L 50 \
+        --jq '.[] | select(.headSha == "'"$HEAD_SHA"'") | "\(.databaseId)\t\(.status)\t\(.conclusion // "pending")"' \
+        2>&1 | head -1 || true)
+
+    if [[ -n "$MATCH" && ! "$MATCH" == *$'\t'* ]]; then
+        echo "⚠️  gh run list: $MATCH" >&2
+        MATCH=""
+    fi
+
+    if [[ -n "$MATCH" ]]; then
+        IFS=$'\t' read -r RUN_ID STATUS CONCLUSION <<< "$MATCH"
+
+        if [[ "$STATUS" == "completed" ]]; then
+            if [[ "$CONCLUSION" == "success" ]]; then
+                echo "✅ Copilot code review completed (run ${RUN_ID})."
+            else
+                echo "⚠️  Copilot code review completed with conclusion: ${CONCLUSION} (run ${RUN_ID})."
+            fi
+            COPILOT_DONE=true
+            break
+        fi
+        echo "⏳ Copilot code review in progress (run ${RUN_ID}, status: ${STATUS})... [${ELAPSED}s/${COPILOT_TIMEOUT}s]"
+    else
+        echo "⏳ Waiting for Copilot code review to start... [${ELAPSED}s/${COPILOT_TIMEOUT}s]"
+    fi
+
+    sleep "$POLL_INTERVAL"
+    ELAPSED=$((ELAPSED + POLL_INTERVAL))
+done
+
+if [[ "$COPILOT_DONE" != "true" ]]; then
+    echo "⚠️  Copilot review did not complete within ${COPILOT_TIMEOUT}s. Checking threads anyway."
+else
+    echo "Waiting ${THREAD_PROPAGATION_DELAY}s for review threads to propagate..."
+    sleep "$THREAD_PROPAGATION_DELAY"
+fi
+echo ""
+
+# ── Step 3: Check unresolved review threads ──────────────────────────
+
+echo "--- Step 3: Checking unresolved review threads ---"
+
+REVIEW_THREADS_QUERY='query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 5) {
+            nodes {
+              body
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+set +e
+THREADS_OUTPUT=$(gh api graphql \
+    -f query="$REVIEW_THREADS_QUERY" \
+    -f owner="$OWNER" \
+    -f name="$REPO" \
+    -F number="$PR_NUMBER" \
+    --jq '
+        [.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)]
+        | if length == 0 then "NONE"
+          else
+            ( map(
+                "Thread \(.id) by @\(.comments.nodes[0].author.login)"
+                + (if .path then " (\(.path):\(.line // "?"))" else "" end)
+                + ":\n  \(.comments.nodes[0].body | split("\n")[0])"
+              ) | join("\n\n") )
+            + "\n\nTotal: \(length) unresolved thread(s)"
+          end
+    ')
+GQL_EXIT=$?
+set -e
+
+if [[ $GQL_EXIT -ne 0 ]]; then
+    echo "❌ Failed to query review threads." >&2
+    [[ -n "$THREADS_OUTPUT" ]] && echo "$THREADS_OUTPUT" >&2
+    exit 3
+fi
+
+if [[ "$THREADS_OUTPUT" == "NONE" ]]; then
+    echo "✅ No unresolved review threads."
+    echo ""
+    echo "=== PR #${PR_NUMBER} is clean ==="
+    exit 0
+else
+    printf '%s\n' "$THREADS_OUTPUT"
+    echo ""
+    echo "=== PR #${PR_NUMBER} has unresolved review threads ==="
+    exit 1
+fi

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -28,7 +28,8 @@ sudo apt install -y \
   git \
   gnupg \
   build-essential \
-  unzip
+  unzip \
+  dnsutils
 
 # ── Neovim (latest stable from GitHub releases) ───────────────────
 install_neovim() {


### PR DESCRIPTION
## Summary

Adds a structured post-push PR verification workflow to `agent.md` and a companion script, inspired by the jicklejime repo's agent workflow.

### Changes

| File | Change |
|------|--------|
| `.github/copilot/agent.md` | Added collaboration expectations, PR body-file convention, no-force-push policy, and full post-push verification workflow |
| `scripts/wait-for-pr-reviews.sh` | New script that watches CI checks + Copilot code review and reports unresolved review threads |

### What the verification workflow does

1. **Watches CI checks** via `gh pr checks --watch`
2. **Polls for Copilot code review** completion (matches head SHA)
3. **Reports unresolved review threads** via GraphQL
4. Agent addresses feedback, commits, pushes, and iterates until clean

Also includes:
- `dnsutils` added to apt packages in `zsh/init.sh` (from master)
