### PR TITLE
Add WezTerm keybindings and update Treesitter configuration

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775781825,
-        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
+        "lastModified": 1776701552,
+        "narHash": "sha256-CCRzOEFg6JwCdZIR5dLD0ypah5/e2JQVuWQ/l3rYrPY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
+        "rev": "c81775b640d4507339d127f5adb4105f6015edf2",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775763530,
-        "narHash": "sha256-BuTK9z1QEwWPOIakQ1gCN4pa4VwVJpfptYCviy2uOGc=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0188973b4b2a5b6bdba8b65381d6cd09a533da0",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,0 +1,1 @@
+/nix/store/w6071pwis23rc44qnj0fgmjim1fb9krg-home-manager-files/.config/nvim/init.lua

--- a/nvim/nvim-pack-lock.json
+++ b/nvim/nvim-pack-lock.json
@@ -61,7 +61,7 @@
       "src": "https://github.com/mason-org/mason.nvim"
     },
     "mini.nvim": {
-      "rev": "418ef4930ddabe80f449c6f1323f8b6abb172d1c",
+      "rev": "d76247d6e3ffa222784be5b156770e37c665f67e",
       "src": "https://github.com/nvim-mini/mini.nvim"
     },
     "neogit": {
@@ -85,7 +85,7 @@
       "src": "https://github.com/hrsh7th/nvim-cmp"
     },
     "nvim-lspconfig": {
-      "rev": "4b7fbaa239c5db6b36f424a4521ca9f1a401be33",
+      "rev": "e05fb8c3bd61d909dacff24f77f23beb644daf54",
       "src": "https://github.com/neovim/nvim-lspconfig"
     },
     "nvim-nio": {

--- a/nvim/plugin/13_treesitter.lua
+++ b/nvim/plugin/13_treesitter.lua
@@ -6,85 +6,77 @@ vim.pack.add {
   'https://github.com/nvim-treesitter/nvim-treesitter-textobjects'
 }
 
-require('nvim-treesitter.config').setup({
-  ensure_installed = {
-    'bash',
-    'bicep',
-    'c',
-    'cpp',
-    'c_sharp',
-    'css',
-    'csv',
-    'diff',
-    'dockerfile',
-    'editorconfig',
-    'fsharp',
-    'git_config',
-    'git_rebase',
-    'gitattributes',
-    'gitcommit',
-    'gitignore',
-    'gleam',
-    'go',
-    'graphql',
-    'helm',
-    'html',
-    'hurl',
-    'java',
-    'javadoc',
-    'javascript',
-    'jq',
-    'json',
-    'lua',
-    'markdown',
-    'markdown_inline',
-    'powershell',
-    'python',
-    'regex',
-    'terraform',
-    'typescript',
-    'vim',
-    'vimdoc',
-    'yaml',
-  },
-  sync_install = false,
-  highlight = {
-    enable = true,
-    disable = function(lang, buf)
-      local max_filesize = 100 * 1024 -- 100 KB
-      local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
-      if ok and stats and stats.size > max_filesize then
-        return true
-      end
-    end,
-    additional_vim_regex_highlighting = false,
-  },
-  indent = {
-    enable = true,
-  },
-  incremental_selection = {
-    enable = true,
-    keymaps = {
-      init_selection = 'gnn',
-      node_incremental = 'grn',
-      scope_incremental = 'grc',
-      node_decremental = 'grm',
-    },
-  },
-  textobjects = {
-    select = {
-      enable = true,
-      lookahead = true,
-      keymaps = {
-        ['af'] = '@function.outer',
-        ['if'] = '@function.inner',
-        ['ac'] = '@class.outer',
-        ['ic'] = '@class.inner',
-        ['as'] = '@statement.outer',
-        ['is'] = '@statement.inner',
-        ['al'] = '@loop.outer',
-        ['il'] = '@loop.inner',
-      }
-    },
-  },
+local servers = {
+  'bash',
+  'bicep',
+  'c',
+  'cpp',
+  'c_sharp',
+  'css',
+  'csv',
+  'diff',
+  'dockerfile',
+  'editorconfig',
+  'fsharp',
+  'git_config',
+  'git_rebase',
+  'gitattributes',
+  'gitcommit',
+  'gitignore',
+  'gleam',
+  'go',
+  'graphql',
+  'helm',
+  'html',
+  'hurl',
+  'java',
+  'javadoc',
+  'javascript',
+  'jq',
+  'json',
+  'lua',
+  'markdown',
+  'markdown_inline',
+  'powershell',
+  'python',
+  'regex',
+  'terraform',
+  'typescript',
+  'vim',
+  'vimdoc',
+  'yaml'
+}
+
+local treesitter = require('nvim-treesitter')
+treesitter.setup()
+treesitter.install(servers)
+
+require('nvim-treesitter-textobjects').setup()
+
+local set_select = function(maps, selection)
+  vim.keymap.set(
+    { 'x', 'o' },
+    maps,
+    function()
+      require("nvim-treesitter-textobjects.select").select_textobject(selection, "textobjects")
+    end
+  )
+end
+
+set_select('af', '@function.outer')
+set_select('if', '@function.outer')
+set_select('ac', '@class.outer')
+set_select('ic', '@class.inner')
+set_select('as', '@statement.outer')
+set_select('is', '@statement.inner')
+set_select('al', '@loop.outer')
+set_select('il', '@loop.inner')
+
+vim.api.nvim_create_autocmd('FileType', {
+  pattern = servers,
+  callback = function()
+    vim.treesitter.start()
+    vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+    vim.wo[0][0].foldmethod = 'expr'
+  end
 })

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -1,11 +1,90 @@
 local wezterm = require 'wezterm'
 local config = wezterm.config_builder()
+local act = wezterm.action
 
 config.color_scheme = 'rose-pine'
 config.default_prog = { '/etc/profiles/per-user/' .. os.getenv('USER') .. '/bin/fish', '-l' }
 config.font_size = 12
 config.leader = { key = 'a', mods = 'CTRL', timeout_milliseconds = 1000 }
 config.max_fps = 120
+
+config.keys = {
+  -- moving between panes
+  {
+    key = 'Home',
+    mods = 'CTRL',
+    action = act.ActivatePaneDirection('Left')
+  },
+  {
+    key = 'End',
+    mods = 'CTRL',
+    action = act.ActivatePaneDirection('Right')
+  },
+  {
+    key = 'PageUp',
+    mods = 'CTRL',
+    action = act.ActivatePaneDirection('Up')
+  },
+  {
+    key = 'PageDown',
+    mods = 'CTRL',
+    action = act.ActivatePaneDirection('Down')
+  },
+  -- resizing panes
+  {
+    key = 'Home',
+    mods = 'SHIFT',
+    action = act.AdjustPaneSize({ 'Left', 5 })
+  },
+  {
+    key = 'End',
+    mods = 'SHIFT',
+    action = act.AdjustPaneSize({ 'Right', 5 })
+  },
+  {
+    key = 'PageUp',
+    mods = 'SHIFT',
+    action = act.AdjustPaneSize({ 'Up', 5 })
+  },
+  {
+    key = 'PageDown',
+    mods = 'SHIFT',
+    action = act.AdjustPaneSize({ 'Down', 5 })
+  },
+  -- moving between tabs
+  {
+    key = 'Home',
+    mods = 'OPT',
+    action = act.ActivateTabRelative(-1)
+  },
+  {
+    key = 'End',
+    mods = 'OPT',
+    action = act.ActivateTabRelative(1)
+  },
+  -- creating panes
+  {
+    key = 'End',
+    mods = 'CTRL|SHIFT',
+    action = act.SplitHorizontal
+  },
+  {
+    key = 'PageDown',
+    mods = 'CTRL|SHIFT',
+    action = act.SplitVertical
+  },
+  -- rotating panes
+  {
+    key = 'Home',
+    mods = 'CTRL|SHIFT|OPT',
+    action = act.RotatePanes('CounterClockwise')
+  },
+  {
+    key = 'End',
+    mods = 'CTRL|SHIFT|OPT',
+    action = act.RotatePanes('Clockwise')
+  }
+}
 
 wezterm.on("gui-startup", function(cmd)
   local screen            = wezterm.gui.screens().active


### PR DESCRIPTION
This pull request introduces several improvements and refactors to both the Neovim and WezTerm configurations. The most notable changes include a major refactor of the Neovim Treesitter plugin setup for better maintainability and customization, updates to plugin versions, and the addition of custom keybindings for advanced pane and tab management in WezTerm.

**Neovim Treesitter Refactor and Enhancements:**

* Refactored the Treesitter configuration in `13_treesitter.lua` to define supported languages in a separate `servers` table, use new setup and install methods, and move textobject keybindings to explicit Lua keymaps for improved clarity and maintainability. Also added an autocmd to enable Treesitter-based folding per filetype. [[1]](diffhunk://#diff-ce91c2fa43b274c6c072b9ac5bbbb99d8d70f0d3fe19de6a0a2c702544eb17c2L9-R9) [[2]](diffhunk://#diff-ce91c2fa43b274c6c072b9ac5bbbb99d8d70f0d3fe19de6a0a2c702544eb17c2L48-R81)

**Plugin Version Updates:**

* Updated `mini.nvim` and `nvim-lspconfig` plugin versions in `nvim-pack-lock.json` to pull in the latest features and fixes. [[1]](diffhunk://#diff-d64b138face3d99910faba0b03a0e5ab95a9f40a39912c67065249ef85479a41L64-R64) [[2]](diffhunk://#diff-d64b138face3d99910faba0b03a0e5ab95a9f40a39912c67065249ef85479a41L88-R88)

**WezTerm Custom Keybindings:**

* Added a comprehensive set of custom keybindings in `wezterm.lua` for pane movement, resizing, tab navigation, pane splitting, and pane rotation, making terminal navigation and management much more efficient.

**Other:**

* Synced or added the generated or managed Neovim config file at `/nix/store/.../init.lua`