### PR TITLE
docs: audit and update all documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,10 +2,31 @@
 
 ## Repository Overview
 
-Cross-platform dotfiles repository managing configurations for Neovim, PowerShell (Windows), ZSH (Linux/WSL), Windows Terminal, Git, JetBrains IDEs (IdeaVim), and a QMK keyboard layout. All platforms are equally supported — changes should preserve cross-platform compatibility. There are no build/test/lint commands — this is a pure configuration repo deployed via symlinks.
+Cross-platform dotfiles for macOS, Windows, and WSL/Linux. Configs are organized by the program they configure. Active development is on the macOS Nix config (`nix/`). There are no build/test/lint commands — this is a pure configuration repo.
 
-The `archive/` directory contains legacy configs that are no longer actively maintained. Focus work on the active top-level directories.
+| Directory | Platform | What it configures |
+|---|---|---|
+| `nix/` | macOS | nix-darwin + Home Manager: Fish shell, Starship prompt, packages, system settings |
+| `nvim/` | All | Neovim — shared across all platforms |
+| `pwsh/` | Windows | PowerShell profile + winget bootstrap script |
+| `zsh/` | WSL/Linux | ZSH config + full bootstrap script |
+| `wezterm/` | macOS | WezTerm terminal emulator |
+| `wt/` | Windows | Windows Terminal settings |
+| `idea/` | Windows | IdeaVim config for JetBrains IDEs |
+| `archive/` | — | Legacy configs, not maintained |
 
 ## Deployment
 
-Configs are deployed by **symlinking** from this repo to their expected system locations. On Linux/WSL, `zsh/init.sh` handles bootstrap and symlinks including `~/.gitconfig` and the Neovim config. For Windows, symlink manually or adapt the pattern from `archive/symlinkers/`.
+| Platform | Method |
+|---|---|
+| macOS | `sudo darwin-rebuild switch --flake nix/#default --impure` (nix-darwin manages everything) |
+| WSL/Linux | `zsh/init.sh` — installs tools and symlinks `.gitconfig` + `nvim/` into place |
+| Windows | Symlink manually: `$PROFILE`, `$LOCALAPPDATA\nvim`, WT settings, `.ideavimrc` |
+
+## Cross-platform consistency
+
+The same patterns are implemented on every platform: vi keybindings, fzf-based directory navigation (`fd`/`fp`/`fdx`/`fdev`), the same git aliases, Neovim as the editor, and GitHub Copilot CLI. Changes that affect these shared patterns should be considered for all platforms.
+
+## User involvement
+
+The user must approve all non-trivial decisions. **Propose before implementing** anything structural — new tools, config reorganisation, workflow changes. Ask; don't assume.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -2,6 +2,16 @@
 
 Active development is on `nix/`. Prefer declarative changes there over ad hoc setup elsewhere.
 
+## User involvement — read this first
+
+The user wants to understand and approve every non-trivial decision in this repo.
+
+- **Propose before implementing.** For anything structural — adding a tool, changing a workflow, reorganising files — explain what you're thinking and why, then wait for approval.
+- **Explain your reasoning.** Don't just make a change; say what it does and why it's the right call.
+- **Ask when uncertain.** If there are multiple reasonable approaches, surface them. Don't pick one silently.
+- **Never merge a PR.** The user merges everything.
+- Small, obvious fixes (typos, broken paths, stale docs) can proceed without asking. Everything else: ask first.
+
 ## Collaboration expectations
 
 - Keep commits small and focused on a single coherent change.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -1,65 +1,11 @@
 # Agent Instructions
 
-## Collaboration expectations
+This repo is Nix-first. Prefer declarative changes in `nix/` over ad hoc setup elsewhere.
 
-- Keep commits small and focused on a single coherent change.
-- Use conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`, etc.
-- Favor small, composable changes that are easy to review.
+## Working rules
 
-## Git Workflow
-
-Use **trunk-based development** against `master`. Never commit directly to `master`.
-
-- Create **feature branches** for each logical unit of work (e.g., `feat/zsh-core`, `fix/nvim-lsp`)
-- Push the branch and **raise a PR** for review
-- When work spans multiple PRs, **stack branches** (each based on the previous) and note dependencies in PR descriptions
-- Branch naming: `feat/<feature>`, `fix/<issue>`, `docs/<topic>`, `chore/<task>`
-- **Do not rebase or force-push when addressing PR feedback.** Make separate commits for each fix so the review history is visible. PRs are squash-merged, so feature branch commit history does not need to be clean.
-
-## PR Operations
-
-- Before pushing, merge `master` into the feature branch to keep it up to date
-- When creating PRs, include a summary of changes and note any dependencies on other PRs
-- **Use file-based input for PR bodies.** Write the body to a temporary file and pass it via `gh pr create --body-file` or `gh api -F body=@file`. Do not pass markdown inline — shells mangle backticks and special characters.
-- The user reviews every PR before merge. Do not merge PRs without explicit user approval.
-
-## Post-push PR verification
-
-After every push to a PR branch, verify the PR is healthy before considering the work done:
-
-1. **Run the verification script.** Use `scripts/wait-for-pr-reviews.sh <PR_NUMBER>` to wait for CI checks and Copilot code review, then check for unresolved review threads. The script must be run from within the cloned repo. It:
-   - Waits for all CI check runs to complete via `gh pr checks --watch`. Skips gracefully if no CI checks are configured.
-   - Polls for the "Copilot code review" workflow run matching the PR's head SHA, then watches it until completion (default timeout: 5 minutes, configurable with `--timeout`). Skips gracefully if no such workflow exists. CI checks also have a timeout (default: 10 minutes, configurable with `--ci-timeout`).
-   - Queries unresolved review threads via GraphQL (up to 100 threads per PR) and reports them — this catches Copilot review comments regardless of whether the workflow was found.
-   - Exits 0 if clean, 1 if unresolved threads exist, 2 if CI failed, 3 if the thread query failed.
-2. **Address all review feedback.** For each unresolved review thread: fix the issue, commit, push, and reply to the comment thread explaining what changed and referencing the commit SHA.
-   - **Copilot review threads:** After replying, resolve the thread using the GraphQL `resolveReviewThread` mutation so it collapses in the PR timeline.
-   - **Human review threads:** Reply with the fix explanation but **do not resolve** the thread. The reviewer will resolve it after confirming the fix.
-3. **Iterate until clean.** Each fix-and-push cycle triggers new CI runs and may trigger new reviews. Repeat steps 1–2 until all checks pass, all Copilot review threads are resolved, and all human review threads have been replied to.
-
-This applies to every push — initial PR creation, feedback fixes, and follow-up commits alike.
-
-## Bootstrap Scripts
-
-### `zsh/init.sh` — Linux/WSL bootstrap
-
-Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
-
-| Category | Tools |
-|----------|-------|
-| apt packages | zsh, fzf, ripgrep, curl, wget, git, build-essential, unzip |
-| Neovim | Latest stable from GitHub releases (supports `--force` for upgrades) |
-| .NET SDK | Latest LTS via `dotnet-install.sh` to `~/.dotnet` (needed for csharp_ls, fsautocomplete) |
-| nvm + Node | nvm + Node LTS (needed for Copilot CLI, Mason LSP servers) |
-| Oh My Zsh | Framework + zsh-syntax-highlighting, zsh-autosuggestions plugins |
-| GitHub CLI | `gh` from official apt repo |
-| Copilot CLI | `@github/copilot` via npm |
-| Oh My Posh | Prompt theme engine to `~/.local/bin` |
-
-Also configures: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, nvim config symlink, default shell to zsh.
-
-When adding a new tool dependency (e.g., a new Mason LSP server that needs a runtime), add the install step to this script and ensure the runtime's bin directory is on PATH in both `init.sh` and `.zshrc`.
-
-### `win/init.ps1` — Windows bootstrap
-
-Installs dev tools via **winget** (primary) and **Chocolatey** (fallback). Includes Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, and other dev tools. Does not currently install .NET SDK — add via winget if needed.
+- Start with `nix/flake.nix`, `nix/configuration.nix`, and `nix/home.nix`.
+- Treat `archive/` as legacy unless the task explicitly targets it.
+- Keep changes small, direct, and easy to review.
+- Preserve the current Darwin flow: `flake.nix` uses `SUDO_USER`, so apply changes with `sudo darwin-rebuild switch --flake .#default --impure`.
+- There are no repo-wide build, lint, or test commands.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -1,11 +1,65 @@
 # Agent Instructions
 
-This repo is Nix-first. Prefer declarative changes in `nix/` over ad hoc setup elsewhere.
+Active development is on `nix/`. Prefer declarative changes there over ad hoc setup elsewhere.
 
-## Working rules
+## Collaboration expectations
 
-- Start with `nix/flake.nix`, `nix/configuration.nix`, and `nix/home.nix`.
-- Treat `archive/` as legacy unless the task explicitly targets it.
-- Keep changes small, direct, and easy to review.
-- Preserve the current Darwin flow: `flake.nix` uses `SUDO_USER`, so apply changes with `sudo darwin-rebuild switch --flake .#default --impure`.
-- There are no repo-wide build, lint, or test commands.
+- Keep commits small and focused on a single coherent change.
+- Use conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`, etc.
+- Favor small, composable changes that are easy to review.
+
+## Git Workflow
+
+Use **trunk-based development** against `master`. Never commit directly to `master`.
+
+- Create **feature branches** for each logical unit of work (e.g., `feat/nix-packages`, `fix/nvim-lsp`)
+- Push the branch and **raise a PR** for review
+- Branch naming: `feat/<feature>`, `fix/<issue>`, `docs/<topic>`, `chore/<task>`
+- **Do not rebase or force-push when addressing PR feedback.** Make separate commits for each fix. PRs are squash-merged.
+
+## PR Operations
+
+- Before pushing, merge `master` into the feature branch to keep it up to date
+- **Use file-based input for PR bodies.** Write the body to a temp file and pass via `gh pr create --body-file`. Do not pass markdown inline — shells mangle backticks and special characters.
+- The user reviews every PR before merge. Do not merge PRs without explicit user approval.
+
+## Post-push PR verification
+
+After every push to a PR branch, verify the PR is healthy before considering the work done:
+
+1. **Run the verification script.** Use `scripts/wait-for-pr-reviews.sh <PR_NUMBER>` to wait for CI checks and Copilot code review, then check for unresolved review threads. It:
+   - Waits for CI check runs via `gh pr checks --watch` (skips if no CI configured).
+   - Polls for the "Copilot code review" workflow run and watches it to completion.
+   - Queries unresolved review threads via GraphQL and reports them.
+   - Exits 0 if clean, 1 if unresolved threads, 2 if CI failed, 3 if thread query failed.
+2. **Address all review feedback.** For each unresolved thread: fix, commit, push, reply with the commit SHA.
+   - **Copilot threads:** Resolve via GraphQL `resolveReviewThread` after replying.
+   - **Human threads:** Reply but **do not resolve** — let the reviewer do it.
+3. **Iterate until clean.**
+
+## Bootstrap Scripts
+
+### `zsh/init.sh` — Linux/WSL bootstrap
+
+Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
+
+| Category | Tools |
+|----------|-------|
+| apt packages | zsh, fzf, ripgrep, curl, wget, git, build-essential, unzip |
+| Neovim | Latest stable from GitHub releases (supports `--force` for upgrades) |
+| .NET SDK | Latest LTS via `dotnet-install.sh` to `~/.dotnet` (needed for csharp_ls, fsautocomplete) |
+| nvm + Node | nvm + Node LTS (needed for Copilot CLI, Mason LSP servers) |
+| Oh My Zsh | Framework + zsh-syntax-highlighting, zsh-autosuggestions plugins |
+| GitHub CLI | `gh` from official apt repo |
+| Azure CLI | From Microsoft's apt repo |
+| Terraform | From HashiCorp's apt repo |
+| Copilot CLI | `@github/copilot` via npm |
+| Oh My Posh | Prompt theme engine to `~/.local/bin` |
+
+Also configures: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, nvim config symlink, default shell to zsh.
+
+When adding a new tool dependency, add the install step to this script and ensure the runtime's bin directory is on PATH in both `init.sh` and `.zshrc`.
+
+### `pwsh/init.ps1` — Windows bootstrap
+
+Installs dev tools via **winget**: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and others. Uses Chocolatey as a fallback for tools not on winget. Also installs the Copilot CLI via npm.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -37,11 +37,7 @@ Use **trunk-based development** against `master`. Never commit directly to `mast
 
 After every push to a PR branch, verify the PR is healthy before considering the work done:
 
-1. **Run the verification script.** Use `scripts/wait-for-pr-reviews.sh <PR_NUMBER>` to wait for CI checks and Copilot code review, then check for unresolved review threads. It:
-   - Waits for CI check runs via `gh pr checks --watch` (skips if no CI configured).
-   - Polls for the "Copilot code review" workflow run and watches it to completion.
-   - Queries unresolved review threads via GraphQL and reports them.
-   - Exits 0 if clean, 1 if unresolved threads, 2 if CI failed, 3 if thread query failed.
+1. **Check CI and review status.** Use `gh pr checks --watch <PR_NUMBER>` to wait for CI, then inspect any Copilot code review for unresolved threads.
 2. **Address all review feedback.** For each unresolved thread: fix, commit, push, reply with the commit SHA.
    - **Copilot threads:** Resolve via GraphQL `resolveReviewThread` after replying.
    - **Human threads:** Reply but **do not resolve** — let the reviewer do it.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ sudo darwin-rebuild switch --flake .#default --impure
 
 `--impure` is required: the flake reads `$SUDO_USER` at eval time to avoid hardcoding a username.
 
+> **Apple Silicon only.** The flake hardcodes `system = "aarch64-darwin"`. It will not evaluate on Intel Macs without modification.
+
 > **Corporate proxy?** See [Corporate SSL/TLS Setup](#corporate-ssltls-setup) before running `darwin-rebuild`.
 
 ### Windows — PowerShell
@@ -100,10 +102,10 @@ Plugin files live in `nvim/plugin/` and are auto-sourced alphabetically at start
 |---|---|
 | **UI** | Rose Pine colorscheme, mini.nvim (statusline, tabline, file explorer, icons) |
 | **Fuzzy finding** | mini.pick (ripgrep-backed) — `<leader>f*` for files, grep, git, buffers, diagnostics |
-| **Syntax** | Treesitter with 47 language parsers; AST-based text objects (`af/if`, `ac/ic`, `al/il`) |
-| **LSP** | Mason + nvim-lspconfig; 16 servers: Bash, C#, F#, Python, Lua, TypeScript, Terraform, YAML, and more |
+| **Syntax** | Treesitter with 38 language parsers; AST-based text objects (`af/if`, `ac/ic`, `al/il`) |
+| **LSP** | Mason + nvim-lspconfig; 16 servers: Bash, Bicep, C#, CSS, Docker, ESLint, F#, GraphQL, HTML, JSON, XML, Lua, PowerShell, Python, Vimscript, YAML |
 | **Completion** | nvim-cmp; sources: Copilot → LSP → snippets → buffer → paths |
-| **AI** | copilot.lua (inline) + CodeCompanion (chat, GPT-4) |
+| **AI** | copilot.lua (inline) + CodeCompanion (chat via Copilot) |
 | **Git** | Neogit (`<leader>gg`) + Diffview (side-by-side diffs, merge tool) |
 | **Tests** | Neotest + neotest-vstest (C#/.NET) |
 | **Markdown** | render-markdown.nvim (renders in-buffer) |
@@ -156,7 +158,7 @@ nix/
 
 **Git** is configured declaratively in `home.nix`: user info, openpgp signing, and all aliases match the other platforms.
 
-**Corporate SSL/TLS:** If `~/.corporate-ca.pem` exists, `home.nix` automatically injects a combined CA bundle into `NIX_SSL_CERT_FILE`, `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, and `GIT_SSL_CAINFO`. See [Corporate SSL/TLS Setup](#corporate-ssltls-setup).
+**Corporate SSL/TLS:** If `~/.corporate-ca.pem` exists, `home.nix` automatically injects `~/.combined-ca-bundle.pem` into `NIX_SSL_CERT_FILE`, `SSL_CERT_FILE`, and `GIT_SSL_CAINFO`, and sets `NODE_EXTRA_CA_CERTS` to `~/.corporate-ca.pem`. See [Corporate SSL/TLS Setup](#corporate-ssltls-setup).
 
 ---
 
@@ -301,4 +303,4 @@ curl -sS -o /dev/null -w "%{http_code}" https://api.github.com
 # 200
 ```
 
-`nix/home.nix` automatically detects `~/.corporate-ca.pem` and injects the bundle into `NIX_SSL_CERT_FILE`, `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, and `GIT_SSL_CAINFO`. Rebuild the bundle after any `darwin-rebuild switch` that updates the Nix CA store, or when your company rotates its proxy CA.
+`nix/home.nix` automatically detects `~/.corporate-ca.pem` and injects `~/.combined-ca-bundle.pem` into `NIX_SSL_CERT_FILE`, `SSL_CERT_FILE`, and `GIT_SSL_CAINFO`. `NODE_EXTRA_CA_CERTS` is set to `~/.corporate-ca.pem` directly. Rebuild the bundle after any `darwin-rebuild switch` that updates the Nix CA store, or when your company rotates its proxy CA.

--- a/README.md
+++ b/README.md
@@ -1,38 +1,59 @@
 # dotfiles
 
-Cross-platform dotfiles managing configurations for Neovim, PowerShell (Windows), ZSH (WSL), Fish (macOS via Nix), WezTerm, Windows Terminal, Git, and IdeaVim. Active development is on `nix/`.
+Cross-platform developer environment. Same editor, same muscle memory, same git aliases — macOS, Windows, or WSL.
+
+Active development is on the macOS Nix config. Everything is organized by the program it configures.
+
+---
+
+## What's Shared Across Platforms
+
+The whole point is consistency. These work the same everywhere:
+
+| Thing | macOS | Windows | WSL/Linux |
+|---|---|---|---|
+| Editor | Neovim | Neovim | Neovim |
+| Vi bindings | Fish (vi mode) | PSReadLine vi | zsh vi mode |
+| Prompt | Starship | Oh My Posh (material) | Oh My Posh (material) |
+| Fuzzy nav | `fd`, `fp`, `fdx`, `fdev` | `fd`, `fp`, `fdx`, `fdev` | `fd`, `fp`, `fdx`, `fdev` |
+| Git aliases | `g`, `acp`, `cm`, `d`, `dc`… | `g`, `acp`, `cm`, `d`, `dc`… | `g`, `acp`, `cm`, `d`, `dc`… |
+| AI assistant | Copilot CLI + Neovim | Copilot CLI + Neovim | Copilot CLI + Neovim |
+
+**Fuzzy nav functions** (`fd`/`fp`/`fdx`/`fdev`) use fzf to jump into directories. `fdev` goes further — it opens the chosen directory in a terminal split with Neovim already running alongside. Implemented independently in Fish, ZSH, and PowerShell with identical UX.
+
+---
 
 ## Quick Start
 
-### macOS (nix-darwin + Home Manager)
+### macOS — nix-darwin + Home Manager
 
 ```bash
-# Install Nix if needed: https://nixos.org/download
+# Install Nix first if needed: https://nixos.org/download
 git clone https://github.com/jcmcmaster/dotfiles ~/Projects/dotfiles
 cd ~/Projects/dotfiles/nix
 sudo darwin-rebuild switch --flake .#default --impure
 ```
 
-The flake reads `SUDO_USER` via `builtins.getEnv` (hence `--impure`) so the config isn't tied to a specific user. Fish, Neovim, and dev tools are managed declaratively via Home Manager.
+`--impure` is required: the flake reads `$SUDO_USER` at eval time to avoid hardcoding a username.
 
-If you're behind a **corporate TLS inspection proxy**, see [Corporate SSL/TLS Setup](#corporate-ssltls-setup) before installing LSP servers or other tools.
+> **Corporate proxy?** See [Corporate SSL/TLS Setup](#corporate-ssltls-setup) before running `darwin-rebuild`.
 
-### Windows (PowerShell)
+### Windows — PowerShell
 
 ```powershell
 git clone https://github.com/jcmcmaster/dotfiles $HOME\Projects\dotfiles
 
-# Install tools via winget
+# Install tools (winget + a few extras)
 & $HOME\Projects\dotfiles\pwsh\init.ps1
 
-# Symlink configs to their expected locations:
-# - PowerShell profile → $PROFILE
-# - Neovim config     → $env:LOCALAPPDATA\nvim
-# - Windows Terminal   → WT settings path
-# - .ideavimrc         → $HOME\.ideavimrc
+# Symlink manually:
+#   $PROFILE                         → pwsh/Microsoft.PowerShell_profile.ps1
+#   $env:LOCALAPPDATA\nvim           → nvim/
+#   Windows Terminal settings path   → wt/settings.json
+#   $HOME\.ideavimrc                 → idea/.ideavimrc
 ```
 
-### Ubuntu / WSL (ZSH)
+### WSL / Ubuntu — ZSH
 
 ```bash
 git clone https://github.com/jcmcmaster/dotfiles ~/projects/dotfiles
@@ -41,111 +62,243 @@ chmod +x ~/projects/dotfiles/zsh/init.sh
 exec zsh
 ```
 
-The init script installs zsh, Oh My Zsh, Oh My Posh, Neovim, fzf, Azure CLI, Terraform, and plugins. It sets up `~/.zshenv` with `ZDOTDIR` pointing to the repo, symlinks `~/.gitconfig`, and symlinks the Neovim config.
+The bootstrap script handles everything: installs tools, sets ZSH as default, and symlinks `~/.gitconfig` and `~/.config/nvim` into the repo.
 
-## Structure
+---
 
-| Directory | Purpose |
-|-----------|---------|
-| `nix/` | nix-darwin + Home Manager config for macOS (Fish, Starship, packages, system settings) |
-| `nvim/` | Neovim config (cross-platform, Lua) |
-| `pwsh/` | PowerShell profile and Windows init script |
-| `zsh/` | ZSH config for WSL (Oh My Zsh + Oh My Posh, vi mode, fzf) |
-| `wezterm/` | WezTerm terminal config |
-| `wt/` | Windows Terminal settings |
-| `idea/` | IdeaVim config (`.ideavimrc`) |
-| `archive/` | Legacy configs (no longer actively maintained) |
+## Repository Layout
 
-## ZSH Configuration (`zsh/`)
+```
+dotfiles/
+├── nix/          macOS system + user environment (nix-darwin, Home Manager)
+├── nvim/         Neovim config — cross-platform, pure Lua
+├── pwsh/         PowerShell profile + Windows bootstrap script
+├── zsh/          ZSH config + WSL bootstrap script
+├── wezterm/      WezTerm terminal emulator config
+├── wt/           Windows Terminal settings
+├── idea/         IdeaVim config for JetBrains IDEs
+└── archive/      Legacy configs, not maintained
+```
 
-Modular ZSH setup for Ubuntu/WSL using **Oh My Zsh** as the framework and **Oh My Posh** (material theme) for the prompt.
+---
 
-### How it works
+## Neovim (`nvim/`)
 
-Uses ZSH's `ZDOTDIR` feature — a single `~/.zshenv` file sets `ZDOTDIR=~/projects/dotfiles/zsh`, and ZSH loads `.zshrc` and all config from the repo directory. No other files need to live in `~`.
+Single config, runs everywhere. Uses Neovim's **built-in `vim.pack`** — no lazy.nvim, no packer, no plugin manager overhead.
 
-### Files
+Plugin files live in `nvim/plugin/` and are auto-sourced alphabetically at startup. They're numbered to enforce load order:
+
+| Phase | Files | Purpose |
+|---|---|---|
+| `0*` | `01_opt`, `02_map`, `03_auto` | Options, keymaps, autocommands |
+| `1*` | `10_mini` … `17_test` | Individual plugins |
+| `2*` | `20_completion` | Higher-order plugins (wrap others) |
+
+### Plugins
+
+| Category | What |
+|---|---|
+| **UI** | Rose Pine colorscheme, mini.nvim (statusline, tabline, file explorer, icons) |
+| **Fuzzy finding** | mini.pick (ripgrep-backed) — `<leader>f*` for files, grep, git, buffers, diagnostics |
+| **Syntax** | Treesitter with 47 language parsers; AST-based text objects (`af/if`, `ac/ic`, `al/il`) |
+| **LSP** | Mason + nvim-lspconfig; 16 servers: Bash, C#, F#, Python, Lua, TypeScript, Terraform, YAML, and more |
+| **Completion** | nvim-cmp; sources: Copilot → LSP → snippets → buffer → paths |
+| **AI** | copilot.lua (inline) + CodeCompanion (chat, GPT-4) |
+| **Git** | Neogit (`<leader>gg`) + Diffview (side-by-side diffs, merge tool) |
+| **Tests** | Neotest + neotest-vstest (C#/.NET) |
+| **Markdown** | render-markdown.nvim (renders in-buffer) |
+| **Editing** | mini.surround, mini.comment, mini.ai (text objects), mini.snippets + friendly-snippets |
+
+### Key bindings (selected)
+
+| Keys | Action |
+|---|---|
+| `<leader>ff` / `<leader>fg` | Find files / live grep |
+| `<leader>ef` | Open file explorer |
+| `gd` / `gi` / `gr` | LSP: definition / implementation / references |
+| `K` | LSP hover |
+| `<leader>lr` / `<leader>la` | Rename / code action |
+| `ge` / `gE` | Next / previous diagnostic |
+| `<leader>gg` | Open Neogit |
+| `<leader>ac` / `<leader>ai` | AI chat / AI inline |
+| `<leader>tf` / `<leader>tr` | Run file tests / nearest test |
+
+Format on save is enabled for: Bicep, C#, F#, Gleam, JSON, Lua, Markdown, PowerShell, SQL, Terraform, YAML.
+
+Lock file: `nvim-pack-lock.json` pins exact plugin commits for reproducible installs.
+
+---
+
+## macOS — Nix (`nix/`)
+
+Declarative macOS setup via **nix-darwin** + **Home Manager**. One command rebuilds the entire environment.
+
+```
+nix/
+├── flake.nix         Inputs (nixpkgs-unstable, nix-darwin, home-manager) + outputs
+├── configuration.nix System-level: user, Fish shell, Homebrew, Determinate Nix compat
+├── home.nix          User-level: packages, shell, prompt, git, programs
+└── nix.conf          Enable flakes + nix-command
+```
+
+**Shell:** Fish with vi key bindings, zoxide (`cd → z`), fzf integration.
+
+**Prompt:** Starship with `nerd-font-symbols` preset.
+
+**Packages (selected):**
+
+| Dev tools | CLI utilities | Desktop |
+|---|---|---|
+| GitHub CLI, Copilot CLI | ripgrep, fd, bat, jq, yq | WezTerm |
+| Terraform | curl, wget, htop, tree | Chrome, Obsidian, Spotify |
+| Mise (runtime versions) | — | Raycast, Rectangle |
+| JetBrains Rider | — | Keeper (Homebrew cask) |
+
+**Git** is configured declaratively in `home.nix`: user info, openpgp signing, and all aliases match the other platforms.
+
+**Corporate SSL/TLS:** If `~/.corporate-ca.pem` exists, `home.nix` automatically injects a combined CA bundle into `NIX_SSL_CERT_FILE`, `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, and `GIT_SSL_CAINFO`. See [Corporate SSL/TLS Setup](#corporate-ssltls-setup).
+
+---
+
+## ZSH — WSL/Linux (`zsh/`)
+
+**Oh My Zsh** as the plugin framework. **Oh My Posh** (material theme) for the prompt.
+
+Config is loaded via ZSH's `ZDOTDIR` — a single `~/.zshenv` points ZSH at the repo, so nothing else needs to live in `~`.
 
 | File | Purpose |
-|------|---------|
-| `.zshrc` | Main config: Oh My Zsh + Oh My Posh prompt, sources modular files |
-| `.gitconfig` | Linux/WSL Git config with aliases, editor, credential helper, and difftool/mergetool setup |
-| `aliases.zsh` | `g`→git, `vim`/`vi`→nvim, common shell aliases |
-| `functions.zsh` | fzf directory navigation (`fd`, `fp`, `fdx`, `fdev`) |
-| `keybindings.zsh` | Vi mode, Ctrl+n/p/y for autosuggestion navigation |
-| `completions.zsh` | dotnet CLI + GitHub Copilot CLI completions |
-| `init.sh` | Bootstrap script (installs everything, sets up symlinks) |
+|---|---|
+| `.zshrc` | Main entry: OMZ, Oh My Posh, sources the modules below |
+| `aliases.zsh` | `g`→git, `vi`/`vim`→nvim, `acp`, `cl`, `cs`, `sz`, etc. |
+| `functions.zsh` | `fd`, `fp`, `fdx`, `fdev`, `owd` (open in Explorer) |
+| `keybindings.zsh` | Vi mode, `^n/^p/^y` for autosuggestions |
+| `completions.zsh` | dotnet CLI + GitHub Copilot CLI tab completions |
+| `.gitconfig` | Git: user, aliases, nvim as editor, Windows credential manager |
+| `init.sh` | Full WSL bootstrap — see below |
 
-### Key functions
+### `init.sh` — What it installs
 
-- **`fd [path] [depth]`** — Fuzzy find a directory and `cd` into it
-- **`fp`** — Fuzzy find in `~/projects` and `cd` into it
-- **`fdx`** — Fuzzy find in `~/Exercism` and `cd` into it
-- **`fdev [path] [depth] [name]`** — Fuzzy find a directory, then open a Windows Terminal tab with a vertical split running nvim
+| Category | Tools |
+|---|---|
+| APT | zsh, fzf, ripgrep, curl, wget, git, build-essential, unzip, gnupg |
+| Editor | Neovim (latest stable, from GitHub releases) |
+| Runtimes | .NET SDK (LTS), nvm + Node LTS |
+| Shell | Oh My Zsh, zsh-syntax-highlighting, zsh-autosuggestions, Oh My Posh |
+| Cloud | GitHub CLI, Azure CLI, Terraform |
+| AI | GitHub Copilot CLI (via npm) |
 
-## Neovim Configuration (`nvim/`)
+Also sets up: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, `~/.config/nvim` symlink, default shell → zsh.
 
-Uses Neovim's **built-in package manager** (`vim.pack`, Neovim 0.11+) with no external plugin manager. Files in `nvim/plugin/` are auto-sourced at startup in numeric order.
+Idempotent — safe to re-run. Use `--force` to reinstall Neovim, `--upgrade` to also run `apt upgrade`.
 
-| File | Purpose |
-|------|---------|
-| `plugin/01_opt.lua` | Editor options (indentation, search, display) |
-| `plugin/02_map.lua` | Global keybindings and leader key setup |
-| `plugin/03_auto.lua` | Autocommands (format-on-save, etc.) |
-| `plugin/10_mini.lua` | mini.nvim suite (statusline, files, fuzzy find) |
-| `plugin/11_color.lua` | Colorscheme |
-| `plugin/12_git.lua` | Git integration |
-| `plugin/13_treesitter.lua` | Treesitter syntax and highlighting |
-| `plugin/14_lsp.lua` | LSP servers via Mason + nvim-lspconfig |
-| `plugin/15_ai.lua` | AI tools (Copilot) |
-| `plugin/16_markdown.lua` | Markdown rendering |
-| `plugin/17_test.lua` | Test runner (neotest) |
-| `plugin/20_completion.lua` | Completion (nvim-cmp) |
-| `nvim-pack-lock.json` | Plugin lock file (pinned commits) |
+---
 
-## PowerShell Profile (`pwsh/`)
+## PowerShell — Windows (`pwsh/`)
 
-- **Oh My Posh** (material theme) for prompt styling
-- **PSReadLine** in Vi mode with history predictions
-- fzf directory navigation (`fd`, `fp`, `fdx`, `fdev`)
-- Aliases: `g`→git, `vim`/`vi`→nvim
-- `init.ps1` installs tools via winget: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and more
+**Oh My Posh** (material theme) + **posh-git** for the prompt. **PSReadLine** in vi mode.
+
+### `Microsoft.PowerShell_profile.ps1`
+
+| Feature | Detail |
+|---|---|
+| Prompt | Oh My Posh, material theme; Terminal-Icons for file icons |
+| Editing | PSReadLine vi mode; `^n/^p` next/prev suggestion, `^y` accept |
+| Git | posh-git module; `g` alias |
+| Navigation | `fd`, `fp`, `fdx`, `fdev` — mirrors the ZSH/Fish implementations |
+| Editor | `vim`/`vi` → nvim |
+| Completions | dotnet CLI argument completer; Copilot CLI aliases |
+| `fdev` | Finds a directory via fzf, opens Windows Terminal with a vertical split: folder pane + Neovim |
+
+### `init.ps1` — What it installs (winget)
+
+Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv), Copilot CLI (npm), `gh-copilot` extension.
+
+---
+
+## WezTerm (`wezterm/`)
+
+Terminal emulator config for macOS. Lua-based.
+
+- **Colorscheme:** Rose Pine (matches Neovim)
+- **Default shell:** Fish (resolved from Nix profile path)
+- **Font size:** 12; **Max FPS:** 120
+- **Leader:** `Ctrl+A`
+- **Startup:** Centered window, 70% of screen size
+- **Pane keybindings:** `Ctrl+Home/End/PgUp/PgDn` to navigate; `Shift+…` to resize; `Ctrl+Shift+End/PgDn` to split; `Opt+Home/End` for tabs
+
+---
+
+## Windows Terminal (`wt/`)
+
+Settings file for Windows Terminal. Covers custom keybindings for pane splitting, tab navigation, focus movement, and pane swapping — mirrors the WezTerm pane model on Windows.
+
+---
+
+## IdeaVim (`idea/`)
+
+`.ideavimrc` for JetBrains IDEs (Rider, etc.). Space as leader — same as Neovim.
+
+Key bindings map JetBrains actions to familiar vim motions:
+
+| Keys | Action |
+|---|---|
+| `gd` / `gi` / `gy` | Declaration / Implementation / Symbol |
+| `gr` / `ge` / `gE` | References / Next error / Prev error |
+| `K` | Hover info |
+| `<leader>ff` / `<leader>fg` | Goto file / Find in path |
+| `<leader>r` / `<leader>ca` | Rename / Intentions |
+| `<leader>cf` | Reformat |
+| `<leader>ta` / `<leader>tc` | Run all tests / Run context tests |
+| `<leader>bb` / `<leader>br` | Build / Rebuild solution |
+| `<C-h>` / `<C-l>` | Previous / Next tab |
+| `<leader>zm` | Zen mode |
+| `<leader><leader>` | AceAction (jump) |
+
+Also sets: relative line numbers, clipboard=unnamed, commentary, ideajoin, hlsearch/incsearch.
+
+---
 
 ## Deployment
 
-Configs are deployed via **symlinks** from this repo to their expected system locations. `zsh/init.sh` handles this for WSL, including `~/.gitconfig` and `~/.config/nvim`. For Windows, symlink manually. On macOS, nix-darwin and Home Manager handle all config placement declaratively.
+| Platform | How configs get deployed |
+|---|---|
+| macOS | nix-darwin + Home Manager manage everything declaratively |
+| WSL/Linux | `zsh/init.sh` symlinks `.gitconfig` and `nvim/` into place |
+| Windows | Symlink manually from the repo to `$PROFILE`, `$LOCALAPPDATA\nvim`, etc. |
+
+---
 
 ## Corporate SSL/TLS Setup
 
-If you're on a corporate network with a **TLS inspection proxy** (e.g., Zscaler, Netskope), tools like curl, Mason, npm, and pip will fail with SSL errors.
+On a network with TLS inspection (Zscaler, Netskope, etc.), Nix, Mason, npm, and pip will fail with certificate errors. The proxy re-signs traffic with a corporate CA that isn't in system trust stores.
 
 ### Fix
 
-1. **Extract the proxy's root CA** from a live connection:
+**1. Extract the proxy's root CA:**
 
-   ```bash
-   echo | openssl s_client -connect github.com:443 -showcerts 2>/dev/null \
-     | awk '/-----BEGIN CERTIFICATE-----/{n++} n==2' > ~/.corporate-ca.pem
+```bash
+echo | openssl s_client -connect github.com:443 -showcerts 2>/dev/null \
+  | awk '/-----BEGIN CERTIFICATE-----/{n++} n==2' > ~/.corporate-ca.pem
 
-   # Verify — subject and issuer should match your company's proxy CA:
-   openssl x509 -in ~/.corporate-ca.pem -noout -subject -issuer
-   ```
+# Verify the subject/issuer look like your corporate proxy CA:
+openssl x509 -in ~/.corporate-ca.pem -noout -subject -issuer
+```
 
-   > **Tip:** The proxy CA may differ from the general corporate root CA in your Keychain. Always extract from a live connection.
+> The proxy CA often differs from the general corporate root CA in Keychain. Always extract from a live connection.
 
-2. **Build a combined CA bundle:**
+**2. Build a combined bundle:**
 
-   ```bash
-   cat /etc/ssl/certs/ca-certificates.crt > ~/.combined-ca-bundle.pem
-   echo "" >> ~/.combined-ca-bundle.pem
-   cat ~/.corporate-ca.pem >> ~/.combined-ca-bundle.pem
-   ```
+```bash
+cat /etc/ssl/certs/ca-certificates.crt > ~/.combined-ca-bundle.pem
+echo "" >> ~/.combined-ca-bundle.pem
+cat ~/.corporate-ca.pem >> ~/.combined-ca-bundle.pem
+```
 
-3. **Restart your terminal** and verify:
+**3. Verify:**
 
-   ```bash
-   curl -sS -o /dev/null -w "%{http_code}" https://api.github.com
-   # Should print: 200
-   ```
+```bash
+curl -sS -o /dev/null -w "%{http_code}" https://api.github.com
+# 200
+```
 
-The env vars pointing tools at `~/.combined-ca-bundle.pem` are already configured in `nix/home.nix` (Fish `interactiveShellInit`). Rebuild the combined bundle after any `darwin-rebuild switch` that updates the Nix CA bundle or if your company rotates its proxy CA.
+`nix/home.nix` automatically detects `~/.corporate-ca.pem` and injects the bundle into `NIX_SSL_CERT_FILE`, `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, and `GIT_SSL_CAINFO`. Rebuild the bundle after any `darwin-rebuild switch` that updates the Nix CA store, or when your company rotates its proxy CA.

--- a/README.md
+++ b/README.md
@@ -1,161 +1,23 @@
 # dotfiles
 
-Cross-platform dotfiles managing configurations for Neovim, PowerShell (Windows), ZSH (WSL), Fish (macOS via Nix), Windows Terminal, Git, and IdeaVim.
+Nix-first dotfiles for macOS. Active development is centered on `nix/`; the other top-level directories are supporting app configs or older platform-specific setup.
 
-## Quick Start
-
-### Windows (PowerShell)
-
-```powershell
-# Clone the repo
-git clone https://github.com/jcmcmaster/dotfiles $HOME\projects\dotfiles
-
-# Run the Windows init script (installs tools via winget/choco)
-& $HOME\projects\dotfiles\win\init.ps1
-
-# Symlink configs to their expected locations:
-# - PowerShell profile → $PROFILE
-# - Neovim config     → $env:LOCALAPPDATA\nvim
-# - Windows Terminal   → WT settings path
-# - .gitconfig         → $HOME\.gitconfig
-# - .ideavimrc         → $HOME\.ideavimrc
-```
-
-### Ubuntu / WSL (ZSH)
+## Apply the config
 
 ```bash
-# Clone the repo
-git clone https://github.com/jcmcmaster/dotfiles ~/projects/dotfiles
-
-# Run the bootstrap script
-chmod +x ~/projects/dotfiles/zsh/init.sh
-~/projects/dotfiles/zsh/init.sh
-
-# Restart your terminal (or: exec zsh)
-```
-
-The init script installs zsh, Oh My Zsh, Oh My Posh, Neovim, fzf, and plugins. It sets up `~/.zshenv` with `ZDOTDIR` pointing to the repo, symlinks `~/.gitconfig`, and symlinks the Neovim config — so only bootstrap-managed files need to live in `~`.
-
-### macOS (nix-darwin + Home Manager)
-
-```bash
-# Install Nix (if not already installed)
-# See https://nixos.org/download
-
-# Clone the repo
 git clone https://github.com/jcmcmaster/dotfiles ~/Projects/dotfiles
-
-# Build and activate (uses $USER for config parameterization)
 cd ~/Projects/dotfiles/nix
 sudo darwin-rebuild switch --flake .#default --impure
 ```
 
-The Nix flake uses `builtins.getEnv` (requires `--impure`) to read the current username so the config isn't tied to a specific machine or user. Fish shell, Neovim, and dev tools are all managed declaratively via Home Manager.
+`flake.nix` reads `SUDO_USER`, so `--impure` is required.
 
-If you're behind a **corporate TLS inspection proxy**, see [Corporate SSL/TLS Setup](#corporate-ssltls-setup) below before installing LSP servers or other tools that download from the internet.
+## Layout
 
-## Structure
-
-| Directory | Purpose |
-|-----------|---------|
-| `nvim/` | Neovim config (cross-platform, Lua) |
-| `nix/` | nix-darwin + Home Manager config for macOS (Fish, packages, system settings) |
-| `powershell/` | PowerShell profile (Oh My Posh, PSReadLine vi mode, fzf) |
-| `zsh/` | ZSH config for WSL (Oh My Zsh + Oh My Posh, vi mode, fzf) |
-| `win/` | Windows init script, `.gitconfig`, `.ideavimrc` |
-| `wt/` | Windows Terminal settings |
-| `keyboard/` | QMK keyboard layout |
-| `archive/` | Legacy Linux configs (no longer actively maintained) |
-
-## ZSH Configuration (`zsh/`)
-
-Modular ZSH setup for Ubuntu/WSL using **Oh My Zsh** as the framework and **Oh My Posh** (material theme) for the prompt.
-
-### How it works
-
-Uses ZSH's `ZDOTDIR` feature — a single `~/.zshenv` file sets `ZDOTDIR=~/projects/dotfiles/zsh`, and ZSH loads `.zshrc` and all config from the repo directory. No other files need to live in `~`.
-
-### Files
-
-| File | Purpose |
-|------|---------|
-| `.zshrc` | Main config: Oh My Zsh + Oh My Posh prompt, sources modular files |
-| `.gitconfig` | Linux/WSL Git config with aliases, editor, credential helper, and difftool/mergetool setup |
-| `aliases.zsh` | `g`→git, `vim`/`vi`→nvim, common shell aliases |
-| `functions.zsh` | fzf directory navigation (`fd`, `fp`, `fdx`, `fdev`) |
-| `keybindings.zsh` | Vi mode, Ctrl+n/p/y for autosuggestion navigation |
-| `completions.zsh` | dotnet CLI + GitHub Copilot CLI completions |
-| `init.sh` | Bootstrap script (installs everything, sets up symlinks) |
-
-### Key functions
-
-- **`fd [path] [depth]`** — Fuzzy find a directory and `cd` into it
-- **`fp`** — Fuzzy find in `~/projects` and `cd` into it
-- **`fdx`** — Fuzzy find in `~/Exercism` and `cd` into it
-- **`fdev [path] [depth] [name]`** — Fuzzy find a directory, then open a Windows Terminal tab with a vertical split running nvim (mirrors the PowerShell `fdev` function)
-
-## Neovim Configuration (`nvim/`)
-
-Uses Neovim's **built-in package manager** (`vim.pack`, Neovim 0.11+) with no external plugin manager. Files in `nvim/plugin/` are auto-sourced by Neovim at startup in numeric order.
-
-| File | Purpose |
-|------|---------|
-| `plugin/01_opt.lua` | Editor options (indentation, search, display) |
-| `plugin/02_map.lua` | Global keybindings and leader key setup |
-| `plugin/03_auto.lua` | Autocommands (format-on-save, etc.) |
-| `plugin/10_mini.lua` | mini.nvim suite (statusline, files, fuzzy find) |
-| `plugin/11_color.lua` | Colorscheme |
-| `plugin/12_git.lua` | Git integration |
-| `plugin/13_treesitter.lua` | Treesitter syntax and highlighting |
-| `plugin/14_lsp.lua` | LSP servers via Mason + nvim-lspconfig |
-| `plugin/15_ai.lua` | AI tools (Copilot) |
-| `plugin/16_markdown.lua` | Markdown rendering |
-| `plugin/17_test.lua` | Test runner (neotest) |
-| `plugin/20_completion.lua` | Completion (nvim-cmp) |
-| `nvim-pack-lock.json` | Plugin lock file (pinned commits) |
-
-## PowerShell Profile (`powershell/`)
-
-- **Oh My Posh** (material theme) for prompt styling
-- **PSReadLine** in Vi mode with history predictions
-- fzf directory navigation (`fd`, `fp`, `fdx`, `fdev`)
-- Aliases: `g`→git, `vim`/`vi`→nvim
-
-## Deployment
-
-Configs are deployed via **symlinks** from this repo to their expected system locations. The `zsh/init.sh` script handles this for WSL, including `~/.gitconfig` and `~/.config/nvim`. For Windows, symlink manually or adapt the pattern from `archive/symlinkers/`. On macOS, nix-darwin and Home Manager handle all config placement declaratively.
-
-## Corporate SSL/TLS Setup
-
-If you're on a corporate network with a **TLS inspection proxy** (e.g., Zscaler, Netskope), tools like curl, Mason, npm, and pip will fail with SSL errors. The proxy re-signs HTTPS traffic with a corporate CA that isn't in the Nix certificate bundle.
-
-### Fix
-
-1. **Extract the proxy's root CA** from a live connection:
-
-   ```bash
-   echo | openssl s_client -connect github.com:443 -showcerts 2>/dev/null \
-     | awk '/-----BEGIN CERTIFICATE-----/{n++} n==2' > ~/.corporate-ca.pem
-
-   # Verify — subject and issuer should match your company's proxy CA:
-   openssl x509 -in ~/.corporate-ca.pem -noout -subject -issuer
-   ```
-
-   > **Tip:** The proxy CA may differ from the general corporate root CA in your Keychain. Always extract from a live connection.
-
-2. **Build a combined CA bundle:**
-
-   ```bash
-   cat /etc/ssl/certs/ca-certificates.crt > ~/.combined-ca-bundle.pem
-   echo "" >> ~/.combined-ca-bundle.pem
-   cat ~/.corporate-ca.pem >> ~/.combined-ca-bundle.pem
-   ```
-
-3. **Restart your terminal** and verify:
-
-   ```bash
-   curl -sS -o /dev/null -w "%{http_code}" https://api.github.com
-   # Should print: 200
-   ```
-
-The env vars pointing tools at `~/.combined-ca-bundle.pem` are already configured in `nix/home.nix` (Fish `interactiveShellInit`). Rebuild the combined bundle after any `darwin-rebuild switch` that updates the Nix CA bundle or if your company rotates its proxy CA.
+| Path | Purpose |
+| --- | --- |
+| `nix/` | nix-darwin + Home Manager entrypoint |
+| `nix/configuration.nix` | system-level macOS settings |
+| `nix/home.nix` | user packages and program config |
+| `nvim/`, `wezterm/`, `pwsh/`, `wt/`, `zsh/`, `idea/` | app-specific config kept in the repo |
+| `archive/` | legacy config |

--- a/README.md
+++ b/README.md
@@ -1,23 +1,151 @@
 # dotfiles
 
-Nix-first dotfiles for macOS. Active development is centered on `nix/`; the other top-level directories are supporting app configs or older platform-specific setup.
+Cross-platform dotfiles managing configurations for Neovim, PowerShell (Windows), ZSH (WSL), Fish (macOS via Nix), WezTerm, Windows Terminal, Git, and IdeaVim. Active development is on `nix/`.
 
-## Apply the config
+## Quick Start
+
+### macOS (nix-darwin + Home Manager)
 
 ```bash
+# Install Nix if needed: https://nixos.org/download
 git clone https://github.com/jcmcmaster/dotfiles ~/Projects/dotfiles
 cd ~/Projects/dotfiles/nix
 sudo darwin-rebuild switch --flake .#default --impure
 ```
 
-`flake.nix` reads `SUDO_USER`, so `--impure` is required.
+The flake reads `SUDO_USER` via `builtins.getEnv` (hence `--impure`) so the config isn't tied to a specific user. Fish, Neovim, and dev tools are managed declaratively via Home Manager.
 
-## Layout
+If you're behind a **corporate TLS inspection proxy**, see [Corporate SSL/TLS Setup](#corporate-ssltls-setup) before installing LSP servers or other tools.
 
-| Path | Purpose |
-| --- | --- |
-| `nix/` | nix-darwin + Home Manager entrypoint |
-| `nix/configuration.nix` | system-level macOS settings |
-| `nix/home.nix` | user packages and program config |
-| `nvim/`, `wezterm/`, `pwsh/`, `wt/`, `zsh/`, `idea/` | app-specific config kept in the repo |
-| `archive/` | legacy config |
+### Windows (PowerShell)
+
+```powershell
+git clone https://github.com/jcmcmaster/dotfiles $HOME\Projects\dotfiles
+
+# Install tools via winget
+& $HOME\Projects\dotfiles\pwsh\init.ps1
+
+# Symlink configs to their expected locations:
+# - PowerShell profile → $PROFILE
+# - Neovim config     → $env:LOCALAPPDATA\nvim
+# - Windows Terminal   → WT settings path
+# - .ideavimrc         → $HOME\.ideavimrc
+```
+
+### Ubuntu / WSL (ZSH)
+
+```bash
+git clone https://github.com/jcmcmaster/dotfiles ~/projects/dotfiles
+chmod +x ~/projects/dotfiles/zsh/init.sh
+~/projects/dotfiles/zsh/init.sh
+exec zsh
+```
+
+The init script installs zsh, Oh My Zsh, Oh My Posh, Neovim, fzf, Azure CLI, Terraform, and plugins. It sets up `~/.zshenv` with `ZDOTDIR` pointing to the repo, symlinks `~/.gitconfig`, and symlinks the Neovim config.
+
+## Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `nix/` | nix-darwin + Home Manager config for macOS (Fish, Starship, packages, system settings) |
+| `nvim/` | Neovim config (cross-platform, Lua) |
+| `pwsh/` | PowerShell profile and Windows init script |
+| `zsh/` | ZSH config for WSL (Oh My Zsh + Oh My Posh, vi mode, fzf) |
+| `wezterm/` | WezTerm terminal config |
+| `wt/` | Windows Terminal settings |
+| `idea/` | IdeaVim config (`.ideavimrc`) |
+| `archive/` | Legacy configs (no longer actively maintained) |
+
+## ZSH Configuration (`zsh/`)
+
+Modular ZSH setup for Ubuntu/WSL using **Oh My Zsh** as the framework and **Oh My Posh** (material theme) for the prompt.
+
+### How it works
+
+Uses ZSH's `ZDOTDIR` feature — a single `~/.zshenv` file sets `ZDOTDIR=~/projects/dotfiles/zsh`, and ZSH loads `.zshrc` and all config from the repo directory. No other files need to live in `~`.
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `.zshrc` | Main config: Oh My Zsh + Oh My Posh prompt, sources modular files |
+| `.gitconfig` | Linux/WSL Git config with aliases, editor, credential helper, and difftool/mergetool setup |
+| `aliases.zsh` | `g`→git, `vim`/`vi`→nvim, common shell aliases |
+| `functions.zsh` | fzf directory navigation (`fd`, `fp`, `fdx`, `fdev`) |
+| `keybindings.zsh` | Vi mode, Ctrl+n/p/y for autosuggestion navigation |
+| `completions.zsh` | dotnet CLI + GitHub Copilot CLI completions |
+| `init.sh` | Bootstrap script (installs everything, sets up symlinks) |
+
+### Key functions
+
+- **`fd [path] [depth]`** — Fuzzy find a directory and `cd` into it
+- **`fp`** — Fuzzy find in `~/projects` and `cd` into it
+- **`fdx`** — Fuzzy find in `~/Exercism` and `cd` into it
+- **`fdev [path] [depth] [name]`** — Fuzzy find a directory, then open a Windows Terminal tab with a vertical split running nvim
+
+## Neovim Configuration (`nvim/`)
+
+Uses Neovim's **built-in package manager** (`vim.pack`, Neovim 0.11+) with no external plugin manager. Files in `nvim/plugin/` are auto-sourced at startup in numeric order.
+
+| File | Purpose |
+|------|---------|
+| `plugin/01_opt.lua` | Editor options (indentation, search, display) |
+| `plugin/02_map.lua` | Global keybindings and leader key setup |
+| `plugin/03_auto.lua` | Autocommands (format-on-save, etc.) |
+| `plugin/10_mini.lua` | mini.nvim suite (statusline, files, fuzzy find) |
+| `plugin/11_color.lua` | Colorscheme |
+| `plugin/12_git.lua` | Git integration |
+| `plugin/13_treesitter.lua` | Treesitter syntax and highlighting |
+| `plugin/14_lsp.lua` | LSP servers via Mason + nvim-lspconfig |
+| `plugin/15_ai.lua` | AI tools (Copilot) |
+| `plugin/16_markdown.lua` | Markdown rendering |
+| `plugin/17_test.lua` | Test runner (neotest) |
+| `plugin/20_completion.lua` | Completion (nvim-cmp) |
+| `nvim-pack-lock.json` | Plugin lock file (pinned commits) |
+
+## PowerShell Profile (`pwsh/`)
+
+- **Oh My Posh** (material theme) for prompt styling
+- **PSReadLine** in Vi mode with history predictions
+- fzf directory navigation (`fd`, `fp`, `fdx`, `fdev`)
+- Aliases: `g`→git, `vim`/`vi`→nvim
+- `init.ps1` installs tools via winget: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and more
+
+## Deployment
+
+Configs are deployed via **symlinks** from this repo to their expected system locations. `zsh/init.sh` handles this for WSL, including `~/.gitconfig` and `~/.config/nvim`. For Windows, symlink manually. On macOS, nix-darwin and Home Manager handle all config placement declaratively.
+
+## Corporate SSL/TLS Setup
+
+If you're on a corporate network with a **TLS inspection proxy** (e.g., Zscaler, Netskope), tools like curl, Mason, npm, and pip will fail with SSL errors.
+
+### Fix
+
+1. **Extract the proxy's root CA** from a live connection:
+
+   ```bash
+   echo | openssl s_client -connect github.com:443 -showcerts 2>/dev/null \
+     | awk '/-----BEGIN CERTIFICATE-----/{n++} n==2' > ~/.corporate-ca.pem
+
+   # Verify — subject and issuer should match your company's proxy CA:
+   openssl x509 -in ~/.corporate-ca.pem -noout -subject -issuer
+   ```
+
+   > **Tip:** The proxy CA may differ from the general corporate root CA in your Keychain. Always extract from a live connection.
+
+2. **Build a combined CA bundle:**
+
+   ```bash
+   cat /etc/ssl/certs/ca-certificates.crt > ~/.combined-ca-bundle.pem
+   echo "" >> ~/.combined-ca-bundle.pem
+   cat ~/.corporate-ca.pem >> ~/.combined-ca-bundle.pem
+   ```
+
+3. **Restart your terminal** and verify:
+
+   ```bash
+   curl -sS -o /dev/null -w "%{http_code}" https://api.github.com
+   # Should print: 200
+   ```
+
+The env vars pointing tools at `~/.combined-ca-bundle.pem` are already configured in `nix/home.nix` (Fish `interactiveShellInit`). Rebuild the combined bundle after any `darwin-rebuild switch` that updates the Nix CA bundle or if your company rotates its proxy CA.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Cross-platform developer environment. Same editor, same muscle memory, same git aliases — macOS, Windows, or WSL.
+Cross-platform dotfiles. Configurations for macOS (Nix), Windows (PowerShell), and WSL/Linux (ZSH), with a shared Neovim config.
 
 Active development is on the macOS Nix config. Everything is organized by the program it configures.
 
@@ -8,7 +8,7 @@ Active development is on the macOS Nix config. Everything is organized by the pr
 
 ## What's Shared Across Platforms
 
-The whole point is consistency. These work the same everywhere:
+The following work the same on all three platforms:
 
 | Thing | macOS | Windows | WSL/Linux |
 |---|---|---|---|
@@ -19,7 +19,7 @@ The whole point is consistency. These work the same everywhere:
 | Git aliases | `g`, `acp`, `cm`, `d`, `dc`… | `g`, `acp`, `cm`, `d`, `dc`… | `g`, `acp`, `cm`, `d`, `dc`… |
 | AI assistant | Copilot CLI + Neovim | Copilot CLI + Neovim | Copilot CLI + Neovim |
 
-**Fuzzy nav functions** (`fd`/`fp`/`fdx`/`fdev`) use fzf to jump into directories. `fdev` goes further — it opens the chosen directory in a terminal split with Neovim already running alongside. Implemented independently in Fish, ZSH, and PowerShell with identical UX.
+**Fuzzy nav functions** (`fd`/`fp`/`fdx`/`fdev`) use fzf to jump into directories. `fdev` opens the chosen directory in a terminal split with Neovim running alongside. Implemented independently in Fish, ZSH, and PowerShell.
 
 ---
 
@@ -84,7 +84,7 @@ dotfiles/
 
 ## Neovim (`nvim/`)
 
-Single config, runs everywhere. Uses Neovim's **built-in `vim.pack`** — no lazy.nvim, no packer, no plugin manager overhead.
+Single config, runs everywhere. Uses Neovim's **built-in `vim.pack`** as the plugin manager — no lazy.nvim or packer.
 
 Plugin files live in `nvim/plugin/` and are auto-sourced alphabetically at startup. They're numbered to enforce load order:
 
@@ -131,7 +131,7 @@ Lock file: `nvim-pack-lock.json` pins exact plugin commits for reproducible inst
 
 ## macOS — Nix (`nix/`)
 
-Declarative macOS setup via **nix-darwin** + **Home Manager**. One command rebuilds the entire environment.
+Declarative macOS setup via **nix-darwin** + **Home Manager**.
 
 ```
 nix/


### PR DESCRIPTION
Full documentation overhaul for the dotfiles repo. Audited every file outside `archive/` and rewrote the README from scratch, then made targeted corrections based on code review feedback.

## Changes

### README.md
- Complete rewrite: cross-platform consistency table, per-platform quick starts, full Neovim plugin inventory + keybinding tables, macOS Nix package list, ZSH/PowerShell install tables, WezTerm config, IdeaVim keybinding reference, corporate SSL/TLS guide
- Corrected from review: Apple Silicon only caveat, Treesitter parser count (38), accurate LSP server list, CodeCompanion uses Copilot not GPT-4, `NODE_EXTRA_CA_CERTS` wiring
- Toned down sales-pitch language throughout

### .github/copilot/agent.md
- Added "User involvement" section at top: propose before implementing, explain reasoning, ask when uncertain, never merge PRs
- Removed stale reference to `scripts/wait-for-pr-reviews.sh` (script no longer exists)
- Updated post-push verification to use `gh pr checks --watch` directly

### .github/copilot-instructions.md
- Removed stale QMK keyboard reference
- Updated directory table and deployment info to match current repo layout
- Added cross-platform consistency note and user-involvement principle
