### PR TITLE
feat(wez): scrolling and quickselect keybinds

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -13,22 +13,37 @@ config.keys = {
   {
     key = 'LeftArrow',
     mods = 'CTRL|SHIFT',
-    action = wezterm.action.DisableDefaultAssignment
+    action = act.DisableDefaultAssignment
   },
   {
     key = 'RightArrow',
     mods = 'CTRL|SHIFT',
-    action = wezterm.action.DisableDefaultAssignment
+    action = act.DisableDefaultAssignment
   },
   {
     key = 'UpArrow',
     mods = 'CTRL|SHIFT',
-    action = wezterm.action.DisableDefaultAssignment
+    action = act.DisableDefaultAssignment
   },
   {
     key = 'DownArrow',
     mods = 'CTRL|SHIFT',
-    action = wezterm.action.DisableDefaultAssignment
+    action = act.DisableDefaultAssignment
+  },
+  -- scrolling
+  {
+    key = 'PageUp',
+    action = act.ScrollByPage(-1)
+  },
+  {
+    key = 'PageDown',
+    action = act.ScrollByPage(1)
+  },
+  -- quick select
+  {
+    key = 'y',
+    mods = 'CTRL|SHIFT',
+    action = act.QuickSelect
   },
   -- moving between panes
   {


### PR DESCRIPTION
This pull request makes several improvements to the `wezterm/wezterm.lua` configuration, focusing on updating keybinding actions to use a consistent API and adding new shortcuts for scrolling and quick selection.

Keybinding API consistency:

* Replaced all uses of `wezterm.action.DisableDefaultAssignment` with `act.DisableDefaultAssignment` for CTRL+SHIFT arrow keys to standardize the action API usage.

New keybindings:

* Added keybindings for `PageUp` and `PageDown` to enable scrolling by page using `act.ScrollByPage`.
* Introduced a new keybinding for CTRL+SHIFT+y to trigger quick select using `act.QuickSelect`.