### PR TITLE
refactor: split nix-darwin configs by machine

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,7 +19,7 @@ Cross-platform dotfiles for macOS, Windows, and WSL/Linux. Configs are organized
 
 | Platform | Method |
 |---|---|
-| macOS | `home-manager switch --flake nix/#default --impure` for user profile (no sudo); `sudo darwin-rebuild switch --flake nix/#default --impure` for system-level (only when needed) |
+| macOS | `home-manager switch --flake nix/#home --impure` (or `#work`) for user profile (no sudo); `sudo darwin-rebuild switch --flake nix/#home --impure` (or `#work`) for system-level (only when needed) |
 | WSL/Linux | `zsh/init.sh` — installs tools and symlinks `.gitconfig` + `nvim/` into place |
 | Windows | Symlink manually: `$PROFILE`, `$LOCALAPPDATA\nvim`, WT settings, `.ideavimrc` |
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ home-manager switch --flake .#work --impure   # work machine
 
 ```bash
 # First run (darwin-rebuild not yet on PATH):
-sudo nix run nix-darwin -- switch --flake .#default --impure
+sudo nix run nix-darwin -- switch --flake .#home --impure   # home machine
+sudo nix run nix-darwin -- switch --flake .#work --impure   # work machine
 
 # Subsequent runs:
-sudo darwin-rebuild switch --flake .#default --impure
+sudo darwin-rebuild switch --flake .#home --impure   # home machine
+sudo darwin-rebuild switch --flake .#work --impure   # work machine
 ```
 
 `--impure` is required: the flake resolves the username from `$SUDO_USER` when run with `sudo`, otherwise it falls back to `$USER`. That avoids hardcoding a username while keeping Home Manager and nix-darwin aligned.
@@ -174,22 +176,24 @@ Lock file: `nvim-pack-lock.json` pins exact plugin commits for reproducible inst
 Declarative macOS setup with two independent paths:
 
 - **Home Manager (standalone)** — manages the user profile: packages, shell, prompt, git, programs. Run with `home-manager switch` (no sudo).
-- **nix-darwin** — manages system-level concerns only: Fish login shell, Homebrew casks, Determinate Nix compat. Run with `sudo darwin-rebuild switch` when needed.
+- **nix-darwin** — manages system-level concerns only: Fish login shell, Homebrew casks, Determinate Nix compat. Run with `sudo darwin-rebuild switch --flake .#home` or `.#work` when needed.
 
 The flake exports both `homeConfigurations` and `darwinConfigurations`. They are independent — Home Manager is **not** wired through nix-darwin.
 
 ```
 nix/
 ├── flake.nix         Inputs (nixpkgs-unstable, nix-darwin, home-manager) + dual outputs
-├── configuration.nix System-level only: user, Fish login shell, Homebrew, Determinate Nix compat
+├── configuration.nix Shared system-level settings: user, Fish login shell, Homebrew, Determinate Nix compat
 ├── modules/
-│   ├── common.nix    Shared packages, shell, prompt, git, and programs
-│   ├── work.nix      Work-only overrides (currently empty placeholder)
-│   └── home.nix      Home-only packages (currently `ffmpeg`)
+│   ├── common.nix        Shared packages, shell, prompt, git, and programs
+│   ├── home.nix          Home-only Home Manager packages (`ffmpeg`)
+│   ├── work.nix          Work-only Home Manager overrides (currently empty placeholder)
+│   ├── darwin-home.nix   Home-only nix-darwin overrides (`keeper-password-manager`)
+│   └── darwin-work.nix   Work-only nix-darwin overrides (currently empty placeholder)
 └── nix.conf          Enable flakes + nix-command
 ```
 
-The flake exports `homeConfigurations."work"` and `homeConfigurations."home"` — use `--flake .#work` or `--flake .#home` accordingly.
+The flake exports `homeConfigurations."work"` / `"home"` and `darwinConfigurations."work"` / `"home"` — use `--flake .#work` or `--flake .#home` with either `home-manager` or `darwin-rebuild` accordingly.
 
 **Shell:** Fish with vi key bindings, zoxide (`cd → z`), fzf integration.
 
@@ -202,7 +206,7 @@ The flake exports `homeConfigurations."work"` and `homeConfigurations."home"` �
 | GitHub CLI, Copilot CLI | ripgrep, fd, bat, jq, yq | WezTerm |
 | Terraform | curl, wget, htop, tree | Chrome, Obsidian, Spotify |
 | Mise (runtime versions) | — | Raycast, Rectangle |
-| JetBrains Rider | — | Keeper (Homebrew cask) |
+| JetBrains Rider | — | Keeper (home machine only; Homebrew cask) |
 
 **Git** is configured declaratively in `modules/common.nix`: user info, openpgp signing, and all aliases match the other platforms. The `name` and `email` values are passed in from `flake.nix`; `email` still comes from the `EMAIL` env var at build time, so the rebuild must inherit that env var (see [Per-machine identity](#per-machine-identity) above).
 
@@ -312,7 +316,7 @@ Also sets: relative line numbers, clipboard=unnamed, commentary, ideajoin, hlsea
 
 | Platform | How configs get deployed |
 |---|---|
-| macOS | `home-manager switch --flake .#home` (or `#work`) for user profile; `sudo darwin-rebuild switch` for system-level (Homebrew, login shell) |
+| macOS | `home-manager switch --flake .#home` (or `#work`) for user profile; `sudo darwin-rebuild switch --flake .#home` (or `#work`) for system-level (Homebrew, login shell) |
 | WSL/Linux | `zsh/init.sh` symlinks `.gitconfig` and `nvim/` into place |
 | Windows | Symlink manually from the repo to `$PROFILE`, `$LOCALAPPDATA\nvim`, etc. |
 

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, username, ... }: {
+{ username, ... }: {
   users.users.${username} = {
     name = username;
     home = "/Users/${username}";
@@ -13,11 +13,5 @@
 
   system.stateVersion = 4;
 
-  homebrew = {
-    enable = true;
-    casks = [
-      "keeper-password-manager"
-    ];
-  };
+  homebrew.enable = true;
 }
-

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -37,18 +37,22 @@
         }
       ] ++ extraModules;
     };
+    mkDarwin = extraModules: nix-darwin.lib.darwinSystem {
+      inherit system pkgs;
+      specialArgs = { inherit username; };
+      modules = [
+        ./configuration.nix
+      ] ++ extraModules;
+    };
   in {
     homeConfigurations = {
       "work" = mkHome [ ./modules/work.nix ];
       "home" = mkHome [ ./modules/home.nix ];
     };
 
-    darwinConfigurations."default" = nix-darwin.lib.darwinSystem {
-      inherit system pkgs;
-      specialArgs = { inherit username; };
-      modules = [
-        ./configuration.nix
-      ];
+    darwinConfigurations = {
+      "work" = mkDarwin [ ./modules/darwin-work.nix ];
+      "home" = mkDarwin [ ./modules/darwin-home.nix ];
     };
   };
 }

--- a/nix/modules/darwin-home.nix
+++ b/nix/modules/darwin-home.nix
@@ -1,0 +1,5 @@
+{ ... }: {
+  homebrew.casks = [
+    "keeper-password-manager"
+  ];
+}

--- a/nix/modules/darwin-work.nix
+++ b/nix/modules/darwin-work.nix
@@ -1,0 +1,3 @@
+{ ... }: {
+  # Work-specific nix-darwin settings go here
+}


### PR DESCRIPTION
## Summary
- split nix-darwin into `home` and `work` machine targets alongside the existing Home Manager targets
- move Keeper into the home-only nix-darwin module so the work machine no longer installs it
- update the macOS docs to use `.#home` / `.#work` for both Home Manager and nix-darwin

## Validation
- `USER=jcmcmaster EMAIL=test@example.com nix flake show --impure --no-write-lock-file`
- `USER=jcmcmaster nix eval --impure --no-write-lock-file .#darwinConfigurations.home.config.homebrew.casks`
- `USER=jcmcmaster nix eval --impure --no-write-lock-file .#darwinConfigurations.work.config.homebrew.casks`
