### PR TITLE
Refine macOS app management and Copilot tooling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ Cross-platform dotfiles for macOS, Windows, and WSL/Linux. Configs are organized
 
 ## Cross-platform consistency
 
-The same patterns are implemented on every platform: vi keybindings, fzf-based directory navigation (`fd`/`fp`/`fdx`/`fdev`), the same git aliases, Neovim as the editor, and GitHub Copilot CLI. Changes that affect these shared patterns should be considered for all platforms.
+The same patterns are implemented on every platform: vi keybindings, fzf-based directory navigation (`fd`/`fp`/`fdx`/`fdev`), the same git aliases, Neovim as the editor, and GitHub CLI Copilot (`gh copilot`). Changes that affect these shared patterns should be considered for all platforms.
 
 ## User involvement
 

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -54,12 +54,12 @@ Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
 | apt packages | zsh, fzf, ripgrep, curl, wget, git, build-essential, unzip |
 | Neovim | Latest stable from GitHub releases (supports `--force` for upgrades) |
 | .NET SDK | Latest LTS via `dotnet-install.sh` to `~/.dotnet` (needed for csharp_ls, fsautocomplete) |
-| nvm + Node | nvm + Node LTS (needed for Copilot CLI, Mason LSP servers) |
+| nvm + Node | nvm + Node LTS (needed for Mason LSP servers) |
 | Oh My Zsh | Framework + zsh-syntax-highlighting, zsh-autosuggestions plugins |
 | GitHub CLI | `gh` from official apt repo |
 | Azure CLI | From Microsoft's apt repo |
 | Terraform | From HashiCorp's apt repo |
-| Copilot CLI | `@github/copilot` via npm |
+| GitHub CLI Copilot | `gh-copilot` GitHub CLI extension |
 | Oh My Posh | Prompt theme engine to `~/.local/bin` |
 
 Also configures: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, nvim config symlink, default shell to zsh.
@@ -68,4 +68,4 @@ When adding a new tool dependency, add the install step to this script and ensur
 
 ### `pwsh/init.ps1` — Windows bootstrap
 
-Installs dev tools via **winget**: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and others. Uses Chocolatey as a fallback for tools not on winget. Also installs the Copilot CLI via npm.
+Installs dev tools via **winget**: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and others. Uses Chocolatey as a fallback for tools not on winget. Also installs the `gh-copilot` GitHub CLI extension.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -59,7 +59,7 @@ Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
 | GitHub CLI | `gh` from official apt repo |
 | Azure CLI | From Microsoft's apt repo |
 | Terraform | From HashiCorp's apt repo |
-| GitHub CLI Copilot | `gh-copilot` GitHub CLI extension |
+| GitHub CLI Copilot | Built-in `gh copilot` subcommand |
 | Oh My Posh | Prompt theme engine to `~/.local/bin` |
 
 Also configures: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, nvim config symlink, default shell to zsh.
@@ -68,4 +68,4 @@ When adding a new tool dependency, add the install step to this script and ensur
 
 ### `pwsh/init.ps1` — Windows bootstrap
 
-Installs dev tools via **winget**: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and others. Uses Chocolatey as a fallback for tools not on winget. Also installs the `gh-copilot` GitHub CLI extension.
+Installs dev tools via **winget**: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and others. Uses Chocolatey as a fallback for tools not on winget. Then wires up the built-in `gh copilot` aliases for PowerShell.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -68,4 +68,4 @@ When adding a new tool dependency, add the install step to this script and ensur
 
 ### `pwsh/init.ps1` — Windows bootstrap
 
-Installs dev tools via **winget**: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and others. Uses Chocolatey as a fallback for tools not on winget. Then wires up the built-in `gh copilot` aliases for PowerShell.
+Installs dev tools via **winget**: Neovim, Git, Node, Python, Oh My Posh, GitHub CLI, Docker, uv, zig, Gleam, Azure CLI, and others. Uses Chocolatey as a fallback for tools not on winget.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Idempotent — safe to re-run. Use `--force` to reinstall Neovim, `--upgrade` to
 
 ### `init.ps1` — What it installs (winget)
 
-Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv), built-in `gh copilot`.
+Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv). `gh copilot` is expected to be available from the installed `gh`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ nix/
 │   ├── common.nix        Shared packages, shell, prompt, git, and programs
 │   ├── home.nix          Home-only Home Manager packages (`karabiner-elements`, `ffmpeg`)
 │   ├── work.nix          Work-only Home Manager overrides (currently empty placeholder)
-│   ├── darwin-home.nix   Home-only nix-darwin Homebrew casks (`capcut`, `discord`, `docker-desktop`, `keeper-password-manager`, `signal`, `slack`, `steam`)
+│   ├── darwin-home.nix   Home-only nix-darwin Homebrew casks (`capcut`, `discord`, `keeper-password-manager`, `signal`, `slack`, `steam`)
 │   └── darwin-work.nix   Work-only nix-darwin overrides (currently empty placeholder)
 └── nix.conf          Enable flakes + nix-command
 ```

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Idempotent — safe to re-run. Use `--force` to reinstall Neovim, `--upgrade` to
 | Git | posh-git module; `g` alias |
 | Navigation | `fd`, `fp`, `fdx`, `fdev` — mirrors the ZSH/Fish implementations |
 | Editor | `vim`/`vi` → nvim |
-| Completions | dotnet CLI argument completer; `gh copilot` aliases |
+| Completions | dotnet CLI argument completer |
 | `fdev` | Finds a directory via fzf, opens Windows Terminal with a vertical split: folder pane + Neovim |
 
 ### `init.ps1` — What it installs (winget)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ nix/
 ├── configuration.nix Shared system-level settings: user, Fish login shell, Homebrew, shared casks, Determinate Nix compat
 ├── modules/
 │   ├── common.nix        Shared packages, shell, prompt, git, and programs
-│   ├── home.nix          Home-only Home Manager packages (`karabiner-elements`, `ffmpeg`)
+│   ├── home.nix          Home-only Home Manager packages (`ffmpeg`, plus macOS-only `karabiner-elements`)
 │   ├── work.nix          Work-only Home Manager overrides (currently empty placeholder)
 │   ├── darwin-home.nix   Home-only nix-darwin Homebrew casks (`capcut`, `discord`, `keeper-password-manager`, `signal`, `slack`, `steam`)
 │   └── darwin-work.nix   Work-only nix-darwin overrides (currently empty placeholder)

--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ The flake exports `homeConfigurations."work"` / `"home"` and `darwinConfiguratio
 | Dev tools | CLI utilities | Desktop |
 |---|---|---|
 | GitHub CLI (`gh copilot`) | ripgrep, fd, bat, jq, yq | WezTerm |
-| Terraform | curl, wget, htop, tree | Chrome, Obsidian, Spotify |
-| Mise (runtime versions) | — | Raycast, Rectangle |
-| JetBrains Rider | — | Keeper (home machine only; Homebrew cask) |
+| Terraform | curl, wget, htop, tree | Chrome, Obsidian |
+| Mise (runtime versions) | — | Raycast, Rectangle, Spotify (shared Homebrew cask) |
+| JetBrains Rider | — | CapCut, Discord, Keeper, Signal, Slack, Steam (home machine only; Homebrew casks) |
 
 **Git** is configured declaratively in `modules/common.nix`: user info, openpgp signing, and all aliases match the other platforms. The `name` and `email` values are passed in from `flake.nix`; `email` still comes from the `EMAIL` env var at build time, so the rebuild must inherit that env var (see [Per-machine identity](#per-machine-identity) above).
 

--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ nix/
 ├── configuration.nix Shared system-level settings: user, Fish login shell, Homebrew, Determinate Nix compat
 ├── modules/
 │   ├── common.nix        Shared packages, shell, prompt, git, and programs
-│   ├── home.nix          Home-only Home Manager packages (`ffmpeg`)
+│   ├── home.nix          Home-only Home Manager packages (`discord`, `github-copilot-cli`, `karabiner-elements`, `signal-desktop`, `slack`, `ffmpeg`)
 │   ├── work.nix          Work-only Home Manager overrides (currently empty placeholder)
-│   ├── darwin-home.nix   Home-only nix-darwin overrides (`keeper-password-manager`)
+│   ├── darwin-home.nix   Home-only nix-darwin Homebrew casks (`capcut`, `docker-desktop`, `keeper-password-manager`, `steam`)
 │   └── darwin-work.nix   Work-only nix-darwin overrides (currently empty placeholder)
 └── nix.conf          Enable flakes + nix-command
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ The flake exports `homeConfigurations."work"` / `"home"` and `darwinConfiguratio
 
 | Dev tools | CLI utilities | Desktop |
 |---|---|---|
-| GitHub CLI (+ `gh-copilot`) | ripgrep, fd, bat, jq, yq | WezTerm |
+| GitHub CLI (`gh copilot`) | ripgrep, fd, bat, jq, yq | WezTerm |
 | Terraform | curl, wget, htop, tree | Chrome, Obsidian, Spotify |
 | Mise (runtime versions) | — | Raycast, Rectangle |
 | JetBrains Rider | — | Keeper (home machine only; Homebrew cask) |
@@ -239,7 +239,7 @@ Config is loaded via ZSH's `ZDOTDIR` — a single `~/.zshenv` points ZSH at the 
 | Runtimes | .NET SDK (LTS), nvm + Node LTS |
 | Shell | Oh My Zsh, zsh-syntax-highlighting, zsh-autosuggestions, Oh My Posh |
 | Cloud | GitHub CLI, Azure CLI, Terraform |
-| AI | GitHub CLI `gh-copilot` extension |
+| AI | Built-in GitHub CLI `gh copilot` |
 
 Also sets up: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, `~/.config/nvim` symlink, default shell → zsh.
 
@@ -265,7 +265,7 @@ Idempotent — safe to re-run. Use `--force` to reinstall Neovim, `--upgrade` to
 
 ### `init.ps1` — What it installs (winget)
 
-Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv), `gh-copilot` extension.
+Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv), built-in `gh copilot`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following work the same on all three platforms:
 | Prompt | Starship | Oh My Posh (material) | Oh My Posh (material) |
 | Fuzzy nav | `fd`, `fp`, `fdx`, `fdev` | `fd`, `fp`, `fdx`, `fdev` | `fd`, `fp`, `fdx`, `fdev` |
 | Git aliases | `g`, `acp`, `cm`, `d`, `dc`… | `g`, `acp`, `cm`, `d`, `dc`… | `g`, `acp`, `cm`, `d`, `dc`… |
-| AI assistant | Copilot CLI + Neovim | Copilot CLI + Neovim | Copilot CLI + Neovim |
+| AI assistant | `gh copilot` + Neovim | `gh copilot` + Neovim | `gh copilot` + Neovim |
 
 **Fuzzy nav functions** (`fd`/`fp`/`fdx`/`fdev`) use fzf to jump into directories. `fdev` opens the chosen directory in a terminal split with Neovim running alongside. Implemented independently in Fish, ZSH, and PowerShell.
 
@@ -186,7 +186,7 @@ nix/
 ├── configuration.nix Shared system-level settings: user, Fish login shell, Homebrew, Determinate Nix compat
 ├── modules/
 │   ├── common.nix        Shared packages, shell, prompt, git, and programs
-│   ├── home.nix          Home-only Home Manager packages (`discord`, `github-copilot-cli`, `karabiner-elements`, `signal-desktop`, `slack`, `ffmpeg`)
+│   ├── home.nix          Home-only Home Manager packages (`discord`, `karabiner-elements`, `signal-desktop`, `slack`, `ffmpeg`)
 │   ├── work.nix          Work-only Home Manager overrides (currently empty placeholder)
 │   ├── darwin-home.nix   Home-only nix-darwin Homebrew casks (`capcut`, `docker-desktop`, `keeper-password-manager`, `steam`)
 │   └── darwin-work.nix   Work-only nix-darwin overrides (currently empty placeholder)
@@ -203,7 +203,7 @@ The flake exports `homeConfigurations."work"` / `"home"` and `darwinConfiguratio
 
 | Dev tools | CLI utilities | Desktop |
 |---|---|---|
-| GitHub CLI, Copilot CLI | ripgrep, fd, bat, jq, yq | WezTerm |
+| GitHub CLI (+ `gh-copilot`) | ripgrep, fd, bat, jq, yq | WezTerm |
 | Terraform | curl, wget, htop, tree | Chrome, Obsidian, Spotify |
 | Mise (runtime versions) | — | Raycast, Rectangle |
 | JetBrains Rider | — | Keeper (home machine only; Homebrew cask) |
@@ -226,7 +226,7 @@ Config is loaded via ZSH's `ZDOTDIR` — a single `~/.zshenv` points ZSH at the 
 | `aliases.zsh` | `g`→git, `vi`/`vim`→nvim, `acp`, `cl`, `cs`, `sz`, etc. |
 | `functions.zsh` | `fd`, `fp`, `fdx`, `fdev`, `owd` (open in Explorer) |
 | `keybindings.zsh` | Vi mode, `^n/^p/^y` for autosuggestions |
-| `completions.zsh` | dotnet CLI + GitHub Copilot CLI tab completions |
+| `completions.zsh` | dotnet CLI + `gh copilot` aliases |
 | `.gitconfig` | Git: user, aliases, nvim as editor, Windows credential manager |
 | `init.sh` | Full WSL bootstrap — see below |
 
@@ -239,7 +239,7 @@ Config is loaded via ZSH's `ZDOTDIR` — a single `~/.zshenv` points ZSH at the 
 | Runtimes | .NET SDK (LTS), nvm + Node LTS |
 | Shell | Oh My Zsh, zsh-syntax-highlighting, zsh-autosuggestions, Oh My Posh |
 | Cloud | GitHub CLI, Azure CLI, Terraform |
-| AI | GitHub Copilot CLI (via npm) |
+| AI | GitHub CLI `gh-copilot` extension |
 
 Also sets up: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, `~/.config/nvim` symlink, default shell → zsh.
 
@@ -260,12 +260,12 @@ Idempotent — safe to re-run. Use `--force` to reinstall Neovim, `--upgrade` to
 | Git | posh-git module; `g` alias |
 | Navigation | `fd`, `fp`, `fdx`, `fdev` — mirrors the ZSH/Fish implementations |
 | Editor | `vim`/`vi` → nvim |
-| Completions | dotnet CLI argument completer; Copilot CLI aliases |
+| Completions | dotnet CLI argument completer; `gh copilot` aliases |
 | `fdev` | Finds a directory via fzf, opens Windows Terminal with a vertical split: folder pane + Neovim |
 
 ### `init.ps1` — What it installs (winget)
 
-Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv), Copilot CLI (npm), `gh-copilot` extension.
+Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv), `gh-copilot` extension.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ The flake exports both `homeConfigurations` and `darwinConfigurations`. They are
 ```
 nix/
 ├── flake.nix         Inputs (nixpkgs-unstable, nix-darwin, home-manager) + dual outputs
-├── configuration.nix Shared system-level settings: user, Fish login shell, Homebrew, Determinate Nix compat
+├── configuration.nix Shared system-level settings: user, Fish login shell, Homebrew, shared casks, Determinate Nix compat
 ├── modules/
 │   ├── common.nix        Shared packages, shell, prompt, git, and programs
-│   ├── home.nix          Home-only Home Manager packages (`discord`, `karabiner-elements`, `signal-desktop`, `slack`, `ffmpeg`)
+│   ├── home.nix          Home-only Home Manager packages (`karabiner-elements`, `ffmpeg`)
 │   ├── work.nix          Work-only Home Manager overrides (currently empty placeholder)
-│   ├── darwin-home.nix   Home-only nix-darwin Homebrew casks (`capcut`, `docker-desktop`, `keeper-password-manager`, `steam`)
+│   ├── darwin-home.nix   Home-only nix-darwin Homebrew casks (`capcut`, `discord`, `docker-desktop`, `keeper-password-manager`, `signal`, `slack`, `steam`)
 │   └── darwin-work.nix   Work-only nix-darwin overrides (currently empty placeholder)
 └── nix.conf          Enable flakes + nix-command
 ```

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -14,4 +14,8 @@
   system.stateVersion = 4;
 
   homebrew.enable = true;
+  homebrew.casks = [
+    "obsidian"
+    "spotify"
+  ];
 }

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -15,6 +15,7 @@
 
   homebrew.enable = true;
   homebrew.casks = [
+    "docker-desktop"
     "spotify"
   ];
 }

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -15,7 +15,6 @@
 
   homebrew.enable = true;
   homebrew.casks = [
-    "obsidian"
     "spotify"
   ];
 }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777771152,
-        "narHash": "sha256-+J0PGlJpLvo1ukmHM0ksI8PtBDwMCYyh87rbs86F0/c=",
+        "lastModified": 1779027260,
+        "narHash": "sha256-ZbgWWFQmSyM3HQ31nAZk2hJ7OSeNr9uRFHL8jCifY9M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9c9fc9368a6d9e698d03d3780d3b930ebc060334",
+        "rev": "bcb774cfc3268120cd61808629f9aa7dad3750a2",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1779031424,
+        "narHash": "sha256-w/62/SPMA1xyMU2raSDkgn6QWkF4xKeTttdtJ+UV5es=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "3fe4b4fb3cdf49cfe3c0079d315599a53b09b9a7",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777641297,
-        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -16,12 +16,10 @@
     htop
     jetbrains.rider
     jq
-    obsidian
     postman
     raycast
     rectangle
     ripgrep
-    spotify
     terraform
     tree
     tree-sitter

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -10,7 +10,6 @@
     azure-cli
     bat
     curl
-    docker
     fd
     google-chrome
     htop

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -1,4 +1,4 @@
-{ pkgs, name, email, ... }: {
+{ lib, pkgs, name, email, ... }: {
   home = {
     sessionVariables = {
       "EDITOR" = "nvim";
@@ -80,6 +80,12 @@
     enable = true;
     gitCredentialHelper.enable = true;
   };
+
+  home.activation.ghCopilotExtension = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    if ! ${pkgs.gh}/bin/gh extension list 2>/dev/null | grep -q '^github/gh-copilot[[:space:]]'; then
+      run ${pkgs.gh}/bin/gh extension install github/gh-copilot --force
+    fi
+  '';
 
   programs.git = {
     enable = true;

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, name, email, ... }: {
+{ pkgs, name, email, ... }: {
   home = {
     sessionVariables = {
       "EDITOR" = "nvim";
@@ -78,12 +78,6 @@
     enable = true;
     gitCredentialHelper.enable = true;
   };
-
-  home.activation.ghCopilotExtension = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    if ! ${pkgs.gh}/bin/gh extension list 2>/dev/null | grep -q '^github/gh-copilot[[:space:]]'; then
-      run ${pkgs.gh}/bin/gh extension install github/gh-copilot --force
-    fi
-  '';
 
   programs.git = {
     enable = true;

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -16,6 +16,7 @@
     htop
     jetbrains.rider
     jq
+    obsidian
     postman
     raycast
     rectangle

--- a/nix/modules/darwin-home.nix
+++ b/nix/modules/darwin-home.nix
@@ -2,7 +2,6 @@
   homebrew.casks = [
     "capcut"
     "discord"
-    "docker-desktop"
     "keeper-password-manager"
     "signal"
     "slack"

--- a/nix/modules/darwin-home.nix
+++ b/nix/modules/darwin-home.nix
@@ -1,8 +1,11 @@
 { ... }: {
   homebrew.casks = [
     "capcut"
+    "discord"
     "docker-desktop"
     "keeper-password-manager"
+    "signal"
+    "slack"
     "steam"
   ];
 }

--- a/nix/modules/darwin-home.nix
+++ b/nix/modules/darwin-home.nix
@@ -1,5 +1,8 @@
 { ... }: {
   homebrew.casks = [
+    "capcut"
+    "docker-desktop"
     "keeper-password-manager"
+    "steam"
   ];
 }

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -2,7 +2,6 @@
   home.packages = with pkgs; [
     discord
     ffmpeg
-    github-copilot-cli
     karabiner-elements
     signal-desktop
     slack

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -1,9 +1,6 @@
 { pkgs, ... }: {
   home.packages = with pkgs; [
-    discord
     ffmpeg
     karabiner-elements
-    signal-desktop
-    slack
   ];
 }

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -1,5 +1,10 @@
 { pkgs, ... }: {
   home.packages = with pkgs; [
+    discord
     ffmpeg
+    github-copilot-cli
+    karabiner-elements
+    signal-desktop
+    slack
   ];
 }

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -1,6 +1,9 @@
-{ pkgs, ... }: {
-  home.packages = with pkgs; [
-    ffmpeg
-    karabiner-elements
-  ];
+{ lib, pkgs, ... }: {
+  home.packages = with pkgs;
+    [
+      ffmpeg
+    ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [
+      karabiner-elements
+    ];
 }

--- a/nvim/plugin/15_ai.lua
+++ b/nvim/plugin/15_ai.lua
@@ -16,9 +16,9 @@ require('codecompanion').setup({
       agent = "copilot",
       agents = {
         copilot = {
-          cmd = "copilot",
-          args = {},
-          description = "Copilot CLI",
+          cmd = "gh",
+          args = { "copilot" },
+          description = "GitHub CLI Copilot",
           provider = "terminal"
         }
       }

--- a/pwsh/Microsoft.PowerShell_profile.ps1
+++ b/pwsh/Microsoft.PowerShell_profile.ps1
@@ -102,4 +102,8 @@ Import-Module posh-git
 New-Alias vim nvim
 New-Alias vi nvim
 
-. "$env:OneDrive\Documents\PowerShell\gh-copilot.ps1"
+$GH_COPILOT_PROFILE = Join-Path -Path $env:OneDrive -ChildPath "Documents/PowerShell/gh-copilot.ps1"
+if (Test-Path $GH_COPILOT_PROFILE)
+{
+  . $GH_COPILOT_PROFILE
+}

--- a/pwsh/Microsoft.PowerShell_profile.ps1
+++ b/pwsh/Microsoft.PowerShell_profile.ps1
@@ -101,9 +101,3 @@ Import-Module posh-git
 
 New-Alias vim nvim
 New-Alias vi nvim
-
-$GH_COPILOT_PROFILE = Join-Path -Path $env:OneDrive -ChildPath "Documents/PowerShell/gh-copilot.ps1"
-if (Test-Path $GH_COPILOT_PROFILE)
-{
-  . $GH_COPILOT_PROFILE
-}

--- a/pwsh/init.ps1
+++ b/pwsh/init.ps1
@@ -30,6 +30,5 @@ uv tool install "vectorcode<1.0.0"
 uv tool update-shell
 
 gh auth login --web
-gh extension install github/gh-copilot --force
 $GH_COPILOT_PROFILE = Join-Path -Path $(Split-Path -Path $PROFILE -Parent) -ChildPath "gh-copilot.ps1"
 gh copilot alias -- pwsh | Out-File ( New-Item -Path $GH_COPILOT_PROFILE -Force )

--- a/pwsh/init.ps1
+++ b/pwsh/init.ps1
@@ -30,5 +30,3 @@ uv tool install "vectorcode<1.0.0"
 uv tool update-shell
 
 gh auth login --web
-$GH_COPILOT_PROFILE = Join-Path -Path $(Split-Path -Path $PROFILE -Parent) -ChildPath "gh-copilot.ps1"
-gh copilot alias -- pwsh | Out-File ( New-Item -Path $GH_COPILOT_PROFILE -Force )

--- a/pwsh/init.ps1
+++ b/pwsh/init.ps1
@@ -29,8 +29,6 @@ choco install watchexec -y
 uv tool install "vectorcode<1.0.0"
 uv tool update-shell
 
-npm install -g @github/copilot
-
 gh auth login --web
 gh extension install github/gh-copilot --force
 $GH_COPILOT_PROFILE = Join-Path -Path $(Split-Path -Path $PROFILE -Parent) -ChildPath "gh-copilot.ps1"

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -2,13 +2,6 @@ alias g="git"
 alias vim="nvim"
 alias vi="nvim"
 
-# Pin copilot to the WSL-native binary (not the Windows one via /mnt/c)
-copilot() {
-  local wsl_bin
-  wsl_bin="$(whence -p copilot | grep -v '^/mnt/c' | head -1)"
-  "${wsl_bin:-copilot}" "$@"
-}
-
 # Requires avante.nvim plugin (AvanteZen command registered on VeryLazy load)
 alias avante='nvim -c AvanteZen'
 

--- a/zsh/completions.zsh
+++ b/zsh/completions.zsh
@@ -7,7 +7,7 @@ if command -v dotnet &>/dev/null; then
   compctl -K _dotnet_zsh_complete dotnet
 fi
 
-# GitHub Copilot CLI aliases
+# GitHub CLI Copilot aliases
 if command -v gh &>/dev/null; then
   _copilot_aliases="$(gh copilot alias -- zsh 2>/dev/null)" && eval "${_copilot_aliases}"
   unset _copilot_aliases

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -146,12 +146,10 @@ else
 fi
 
 # ── GitHub CLI Copilot ─────────────────────────────────────────────
-if gh extension list 2>/dev/null | grep -q '^github/gh-copilot[[:space:]]'; then
-  echo "GitHub CLI Copilot already installed."
+if gh help copilot >/dev/null 2>&1; then
+  echo "GitHub CLI Copilot available via gh copilot."
 else
-  echo "Installing GitHub CLI Copilot extension..."
-  gh extension install github/gh-copilot --force
-  echo "GitHub CLI Copilot installed."
+  echo "GitHub CLI Copilot is unavailable in this gh build."
 fi
 
 # ── Oh My Posh ─────────────────────────────────────────────────────
@@ -229,7 +227,7 @@ echo "  oh-my-posh         → $(command -v oh-my-posh 2>/dev/null || echo 'not 
 echo "  gh                 → $(command -v gh 2>/dev/null || echo 'not found')"
 echo "  az                 → $(command -v az 2>/dev/null || echo 'not found')"
 echo "  terraform          → $(command -v terraform 2>/dev/null || echo 'not found')"
-echo "  gh-copilot         → $(gh extension list 2>/dev/null | awk '$1 == \"github/gh-copilot\" {print $1; found=1} END {if (!found) print \"not found\"}')"
+echo "  gh copilot         → $(gh help copilot >/dev/null 2>&1 && echo 'built in' || echo 'unavailable')"
 echo "  nvm                → ${HOME}/.nvm"
 echo "  dotnet             → $(command -v dotnet 2>/dev/null || echo 'not found')"
 echo ""

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -146,7 +146,7 @@ else
 fi
 
 # ── GitHub CLI Copilot ─────────────────────────────────────────────
-if gh help copilot >/dev/null 2>&1; then
+if gh copilot --help >/dev/null 2>&1; then
   echo "GitHub CLI Copilot available via gh copilot."
 else
   echo "GitHub CLI Copilot is unavailable in this gh build."
@@ -227,7 +227,7 @@ echo "  oh-my-posh         → $(command -v oh-my-posh 2>/dev/null || echo 'not 
 echo "  gh                 → $(command -v gh 2>/dev/null || echo 'not found')"
 echo "  az                 → $(command -v az 2>/dev/null || echo 'not found')"
 echo "  terraform          → $(command -v terraform 2>/dev/null || echo 'not found')"
-echo "  gh copilot         → $(gh help copilot >/dev/null 2>&1 && echo 'built in' || echo 'unavailable')"
+echo "  gh copilot         → $(gh copilot --help >/dev/null 2>&1 && echo 'available' || echo 'unavailable')"
 echo "  nvm                → ${HOME}/.nvm"
 echo "  dotnet             → $(command -v dotnet 2>/dev/null || echo 'not found')"
 echo ""

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -145,13 +145,13 @@ else
   echo "Terraform already installed: $(terraform --version | head -1)"
 fi
 
-# ── GitHub Copilot CLI ─────────────────────────────────────────────
-if ! command -v copilot &>/dev/null; then
-  echo "Installing GitHub Copilot CLI..."
-  npm install -g @github/copilot
-  echo "Copilot CLI installed: $(copilot --version)"
+# ── GitHub CLI Copilot ─────────────────────────────────────────────
+if gh extension list 2>/dev/null | grep -q '^github/gh-copilot[[:space:]]'; then
+  echo "GitHub CLI Copilot already installed."
 else
-  echo "Copilot CLI already installed: $(copilot --version)"
+  echo "Installing GitHub CLI Copilot extension..."
+  gh extension install github/gh-copilot --force
+  echo "GitHub CLI Copilot installed."
 fi
 
 # ── Oh My Posh ─────────────────────────────────────────────────────
@@ -229,7 +229,7 @@ echo "  oh-my-posh         → $(command -v oh-my-posh 2>/dev/null || echo 'not 
 echo "  gh                 → $(command -v gh 2>/dev/null || echo 'not found')"
 echo "  az                 → $(command -v az 2>/dev/null || echo 'not found')"
 echo "  terraform          → $(command -v terraform 2>/dev/null || echo 'not found')"
-echo "  copilot            → $(command -v copilot 2>/dev/null || echo 'not found')"
+echo "  gh-copilot         → $(gh extension list 2>/dev/null | awk '$1 == \"github/gh-copilot\" {print $1; found=1} END {if (!found) print \"not found\"}')"
 echo "  nvm                → ${HOME}/.nvm"
 echo "  dotnet             → $(command -v dotnet 2>/dev/null || echo 'not found')"
 echo ""


### PR DESCRIPTION
## Summary
- rebalance macOS app management between Home Manager and nix-darwin Homebrew casks
- move Copilot usage from the npm-installed `@github/copilot` path to `gh copilot`
- refresh docs and lockfile updates to match the current branch contents

## Notes
- shared Darwin casks: `docker-desktop`, `spotify`
- home-only Darwin casks: `capcut`, `discord`, `keeper-password-manager`, `signal`, `slack`, `steam`
- `obsidian` remains Nix-managed in `common.nix`
- `karabiner-elements` stays Home Manager-managed but is now gated to Darwin
- `gh copilot` is provided by the current `gh` build and downloads/runs the Copilot CLI on first use