### PR TITLE
docs: switch copilot references to standalone cli

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@ Cross-platform dotfiles for macOS, Windows, and WSL/Linux. Configs are organized
 
 ## Cross-platform consistency
 
-The same patterns are implemented on every platform: vi keybindings, fzf-based directory navigation (`fd`/`fp`/`fdx`/`fdev`), the same git aliases, Neovim as the editor, and GitHub CLI Copilot (`gh copilot`). Changes that affect these shared patterns should be considered for all platforms.
+The same patterns are implemented on every platform: vi keybindings, fzf-based directory navigation (`fd`/`fp`/`fdx`/`fdev`), the same git aliases, Neovim as the editor, and Copilot (`copilot`). Changes that affect these shared patterns should be considered for all platforms.
 
 ## User involvement
 

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -59,7 +59,7 @@ Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
 | GitHub CLI | `gh` from official apt repo |
 | Azure CLI | From Microsoft's apt repo |
 | Terraform | From HashiCorp's apt repo |
-| Copilot | Standalone `copilot` command |
+| Copilot | Standalone `copilot` command (expected on PATH) |
 | Oh My Posh | Prompt theme engine to `~/.local/bin` |
 
 Also configures: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, nvim config symlink, default shell to zsh.

--- a/.github/copilot/agent.md
+++ b/.github/copilot/agent.md
@@ -59,7 +59,7 @@ Idempotent script for fresh Ubuntu/WSL installs. Safe to re-run. Installs:
 | GitHub CLI | `gh` from official apt repo |
 | Azure CLI | From Microsoft's apt repo |
 | Terraform | From HashiCorp's apt repo |
-| GitHub CLI Copilot | Built-in `gh copilot` subcommand |
+| Copilot | Standalone `copilot` command |
 | Oh My Posh | Prompt theme engine to `~/.local/bin` |
 
 Also configures: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, nvim config symlink, default shell to zsh.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following work the same on all three platforms:
 | Prompt | Starship | Oh My Posh (material) | Oh My Posh (material) |
 | Fuzzy nav | `fd`, `fp`, `fdx`, `fdev` | `fd`, `fp`, `fdx`, `fdev` | `fd`, `fp`, `fdx`, `fdev` |
 | Git aliases | `g`, `acp`, `cm`, `d`, `dc`… | `g`, `acp`, `cm`, `d`, `dc`… | `g`, `acp`, `cm`, `d`, `dc`… |
-| AI assistant | `gh copilot` + Neovim | `gh copilot` + Neovim | `gh copilot` + Neovim |
+| AI assistant | `copilot` + Neovim | `copilot` + Neovim | `copilot` + Neovim |
 
 **Fuzzy nav functions** (`fd`/`fp`/`fdx`/`fdev`) use fzf to jump into directories. `fdev` opens the chosen directory in a terminal split with Neovim running alongside. Implemented independently in Fish, ZSH, and PowerShell.
 
@@ -212,7 +212,7 @@ The flake exports `homeConfigurations."work"` / `"home"` and `darwinConfiguratio
 
 | Dev tools | CLI utilities | Desktop |
 |---|---|---|
-| GitHub CLI (`gh copilot`) | ripgrep, fd, bat, jq, yq | WezTerm |
+| Copilot (`copilot`) | ripgrep, fd, bat, jq, yq | WezTerm |
 | Terraform | curl, wget, htop, tree | Chrome, Obsidian |
 | Mise (runtime versions) | — | Raycast, Rectangle, Spotify (shared Homebrew cask) |
 | JetBrains Rider | — | CapCut, Discord, Keeper, Signal, Slack, Steam (home machine only; Homebrew casks) |
@@ -235,7 +235,7 @@ Config is loaded via ZSH's `ZDOTDIR` — a single `~/.zshenv` points ZSH at the 
 | `aliases.zsh` | `g`→git, `vi`/`vim`→nvim, `acp`, `cl`, `cs`, `sz`, etc. |
 | `functions.zsh` | `fd`, `fp`, `fdx`, `fdev`, `owd` (open in Explorer) |
 | `keybindings.zsh` | Vi mode, `^n/^p/^y` for autosuggestions |
-| `completions.zsh` | dotnet CLI + `gh copilot` aliases |
+| `completions.zsh` | dotnet CLI + `copilot` aliases |
 | `.gitconfig` | Git: user, aliases, nvim as editor, Windows credential manager |
 | `init.sh` | Full WSL bootstrap — see below |
 
@@ -248,7 +248,7 @@ Config is loaded via ZSH's `ZDOTDIR` — a single `~/.zshenv` points ZSH at the 
 | Runtimes | .NET SDK (LTS), nvm + Node LTS |
 | Shell | Oh My Zsh, zsh-syntax-highlighting, zsh-autosuggestions, Oh My Posh |
 | Cloud | GitHub CLI, Azure CLI, Terraform |
-| AI | Built-in GitHub CLI `gh copilot` |
+| AI | Standalone `copilot` CLI |
 
 Also sets up: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, `~/.config/nvim` symlink, default shell → zsh.
 
@@ -274,7 +274,7 @@ Idempotent — safe to re-run. Use `--force` to reinstall Neovim, `--upgrade` to
 
 ### `init.ps1` — What it installs (winget)
 
-Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv). `gh copilot` is expected to be available from the installed `gh`.
+Docker, Neovim, Git, Node, Python 3.13, GitHub CLI, Oh My Posh, fzf, ripgrep, jq, Azure CLI, Azure Developer CLI, uv, zig, Gleam, Obsidian, Postman, Meld, PowerShell 7+, Chocolatey. Plus: `watchexec` (choco), `vectorcode` (uv). `copilot` is expected to be available on PATH.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Config is loaded via ZSH's `ZDOTDIR` — a single `~/.zshenv` points ZSH at the 
 | Runtimes | .NET SDK (LTS), nvm + Node LTS |
 | Shell | Oh My Zsh, zsh-syntax-highlighting, zsh-autosuggestions, Oh My Posh |
 | Cloud | GitHub CLI, Azure CLI, Terraform |
-| AI | Standalone `copilot` CLI |
+| AI | Standalone `copilot` CLI (expected on PATH) |
 
 Also sets up: `ZDOTDIR` via `~/.zshenv`, `~/.gitconfig` symlink, `~/.config/nvim` symlink, default shell → zsh.
 

--- a/nvim/plugin/15_ai.lua
+++ b/nvim/plugin/15_ai.lua
@@ -16,9 +16,9 @@ require('codecompanion').setup({
       agent = "copilot",
       agents = {
         copilot = {
-          cmd = "gh",
-          args = { "copilot" },
-          description = "GitHub CLI Copilot",
+          cmd = "copilot",
+          args = {},
+          description = "Standalone Copilot CLI",
           provider = "terminal"
         }
       }

--- a/zsh/completions.zsh
+++ b/zsh/completions.zsh
@@ -9,6 +9,6 @@ fi
 
 # Copilot aliases
 if command -v copilot &>/dev/null; then
-  _copilot_aliases="$(copilot alias -- zsh 2>/dev/null)" && eval "${_copilot_aliases}"
+  _copilot_aliases="$(copilot completion zsh 2>/dev/null)" && eval "${_copilot_aliases}"
   unset _copilot_aliases
 fi

--- a/zsh/completions.zsh
+++ b/zsh/completions.zsh
@@ -7,8 +7,8 @@ if command -v dotnet &>/dev/null; then
   compctl -K _dotnet_zsh_complete dotnet
 fi
 
-# GitHub CLI Copilot aliases
-if command -v gh &>/dev/null; then
-  _copilot_aliases="$(gh copilot alias -- zsh 2>/dev/null)" && eval "${_copilot_aliases}"
+# Copilot aliases
+if command -v copilot &>/dev/null; then
+  _copilot_aliases="$(copilot alias -- zsh 2>/dev/null)" && eval "${_copilot_aliases}"
   unset _copilot_aliases
 fi

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -145,11 +145,11 @@ else
   echo "Terraform already installed: $(terraform --version | head -1)"
 fi
 
-# ── GitHub CLI Copilot ─────────────────────────────────────────────
-if gh copilot --help >/dev/null 2>&1; then
-  echo "GitHub CLI Copilot available via gh copilot."
+# ── Copilot ────────────────────────────────────────────────────────
+if copilot --help >/dev/null 2>&1; then
+  echo "Copilot available via copilot."
 else
-  echo "GitHub CLI Copilot is unavailable in this gh build."
+  echo "Copilot is unavailable in this installation."
 fi
 
 # ── Oh My Posh ─────────────────────────────────────────────────────
@@ -227,7 +227,7 @@ echo "  oh-my-posh         → $(command -v oh-my-posh 2>/dev/null || echo 'not 
 echo "  gh                 → $(command -v gh 2>/dev/null || echo 'not found')"
 echo "  az                 → $(command -v az 2>/dev/null || echo 'not found')"
 echo "  terraform          → $(command -v terraform 2>/dev/null || echo 'not found')"
-echo "  gh copilot         → $(gh copilot --help >/dev/null 2>&1 && echo 'available' || echo 'unavailable')"
+echo "  copilot            → $(copilot --help >/dev/null 2>&1 && echo 'available' || echo 'unavailable')"
 echo "  nvm                → ${HOME}/.nvm"
 echo "  dotnet             → $(command -v dotnet 2>/dev/null || echo 'not found')"
 echo ""


### PR DESCRIPTION
Switch repo guidance and config references from `gh copilot` to the standalone `copilot` CLI.

Updates README/docs, ZSH bootstrap/completions, and the CodeCompanion CLI wiring.
